### PR TITLE
PTT support - Allow KeyDown events to leave keys pressed by not dropping Enigo context

### DIFF
--- a/plugins/com.amansprojects.starterpack.sdPlugin/src/main.rs
+++ b/plugins/com.amansprojects.starterpack.sdPlugin/src/main.rs
@@ -46,7 +46,9 @@ impl openaction::ActionEventHandler for ActionEventHandler {
 	) -> EventHandlerResult {
 		match &event.action[..] {
 			"com.amansprojects.starterpack.runcommand" => run_command::down_up("down", event),
-			"com.amansprojects.starterpack.inputsimulation" => input_simulation::key_down(event),
+			"com.amansprojects.starterpack.inputsimulation" => {
+				input_simulation::down_up(event, "down").await
+			}
 			_ => Ok(()),
 		}
 	}
@@ -58,7 +60,9 @@ impl openaction::ActionEventHandler for ActionEventHandler {
 	) -> EventHandlerResult {
 		match &event.action[..] {
 			"com.amansprojects.starterpack.runcommand" => run_command::down_up("up", event),
-			"com.amansprojects.starterpack.inputsimulation" => input_simulation::key_up(event),
+			"com.amansprojects.starterpack.inputsimulation" => {
+				input_simulation::down_up(event, "up").await
+			}
 			"com.amansprojects.starterpack.switchprofile" => {
 				switch_profile::key_up(event, outbound).await
 			}


### PR DESCRIPTION
This PR alters the `key_down` and `key_up` functions in `input_simulation.rs` to not drop the Enigo context between invocations, reducing latency of invocations and allowing for Held (e.g. Push-To-Talk style)  key bindings in OpenDeck.
This also reduces mapping reloads by keeping `xmodmap` keys mapped between invocations, instead of triggering Enigo's cleanup with every interaction.

A mutex is added around the Enigo context to safeguard against concurrent access by multiple calls.