### PR TITLE
fix: make SVG image regex more lenient

### DIFF
--- a/src/lib/rendererHelper.ts
+++ b/src/lib/rendererHelper.ts
@@ -7,7 +7,7 @@ export function getImage(image: string | undefined, fallback: string | undefined
 	if (!image) return fallback ? getImage(fallback, undefined) : "/alert.png";
 	if (image.startsWith("opendeck/")) return image.replace("opendeck", "");
 	if (!image.startsWith("data:")) return "http://localhost:57118/" + image;
-	const svgxmlre = /^data:image\/svg\+xml(?:;\w+=\w+)*,(.+)/;
+	const svgxmlre = /^data:image\/svg\+xml(?!.*?;base64.*?)(?:;[\w=]*)*,(.+)/;
 	const base64re = /^data:image\/(apng|avif|gif|jpeg|png|svg\+xml|webp|bmp|x-icon|tiff);base64,([A-Za-z0-9+/]+={0,2})?/;
 	if (svgxmlre.test(image)) {
 		image = "data:image/svg+xml;base64," + btoa(decodeURIComponent((svgxmlre.exec(image) as RegExpExecArray)[1].replace(/\;$/, "")));


### PR DESCRIPTION
See #94

This should capture all formats whilst ignoring `data` URLs that are already base64-encoded.

Samples to test with:
https://regex101.com/r/DprOEl/2
```
data:image/svg+xml;charset=utf8,<svg>
data:image/svg+xml;utf8,<svg>
data:image/svg+xml;,<svg>
data:image/svg+xml,<svg>
data:image/svg+xml;base64,SGVsbG8gd29ybGQ=
```