### PR TITLE
Prevent plugins from running after they are unregistered

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -264,6 +264,7 @@ Enjoy!"#,
 
 	app.run(|app, event| {
 		if let tauri::RunEvent::Exit = event {
+			futures::executor::block_on(plugins::deactivate_plugins());
 			tokio::spawn(elgato::reset_devices());
 			use tauri_plugin_aptabase::EventTracker;
 			let _ = app.track_event("app_exited", None);

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -327,6 +327,18 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 	}
 }
 
+pub async fn deactivate_plugins() {
+	let uuids = {
+		let instances = INSTANCES.lock().await;
+		instances.keys().cloned().collect::<Vec<_>>()
+	};
+
+	let app = APP_HANDLE.get().unwrap();
+	for uuid in uuids {
+		let _ = deactivate_plugin(app, &uuid).await;
+	}
+}
+
 /// Initialise plugins from the plugins directory.
 pub fn initialise_plugins() {
 	tokio::spawn(init_websocket_server());


### PR DESCRIPTION
This fixes a bug in Windows on which unregistering a plugin would throw an `Access Denied` because of the plugin still running on the background while trying to delete it.
It also unregisters all the plugins when the program exits, preventing them from running in the background after the application is closed, causing problems when trying to reopen the websocket connection.