### PR TITLE
Show property inspector scrollbars only when needed

### DIFF
--- a/src/components/PropertyInspectorView.svelte
+++ b/src/components/PropertyInspectorView.svelte
@@ -162,7 +162,7 @@
 	}}
 />
 
-<div class="grow overflow-scroll bg-white dark:bg-neutral-900 border-t dark:border-neutral-700" bind:this={iframeContainer}>
+<div class="grow overflow-auto bg-white dark:bg-neutral-900 border-t dark:border-neutral-700" bind:this={iframeContainer}>
 	<button
 		bind:this={iframeClosePopup}
 		on:click={() => closePopup(iframePopupsOpen[iframePopupsOpen.length - 1])}


### PR DESCRIPTION
This fixes a bug where scrollbars would be visible even when no proper inspector was shown

Before:
<img width="898" height="672" src="https://github.com/user-attachments/assets/e6a0163a-18e4-4781-8392-ccc4f7c8748e" />

After:
<img width="898" height="672" src="https://github.com/user-attachments/assets/461db63c-ecba-4add-9b4a-6982f18069c3" />
