### PR TITLE
Stop key canvases from flickering

### DIFF
--- a/src/lib/rendererHelper.ts
+++ b/src/lib/rendererHelper.ts
@@ -60,7 +60,6 @@ export async function renderImage(
 
 	const context = canvas.getContext("2d");
 	if (!context) return;
-	context.clearRect(0, 0, canvas.width, canvas.height);
 
 	try {
 		// Load image
@@ -74,10 +73,12 @@ export async function renderImage(
 		});
 
 		// Draw image
+		context.clearRect(0, 0, canvas.width, canvas.height);
 		context.imageSmoothingQuality = "high";
 		context.drawImage(image, 0, 0, canvas.width, canvas.height);
 	} catch (error: any) {
 		if (!(error instanceof Event)) console.error(error);
+		context.clearRect(0, 0, canvas.width, canvas.height);
 		showAlert = true;
 	}
 


### PR DESCRIPTION
This pull request fixes a visual bug where canvases would clear the displayed image before loading the new image, causing it to flicker for a fraction of a second.

Before:
![opendeck_xbleutr1yd](https://github.com/user-attachments/assets/f3d1bfc8-a871-4f4e-a807-62144fdbc62b)

After:
![opendeck_ARBRnib9LR](https://github.com/user-attachments/assets/3df6a875-5a4b-4e1a-9608-d99ef556a711)
