### PR TITLE
Fix bugs when dragging an action

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -12,18 +12,21 @@
 	reload();
 </script>
 
-<div class="grow mt-1 overflow-auto">
+<div class="grow mt-1 overflow-auto select-none">
 	{#each Object.entries(categories).sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0])) as [name, actions]}
 		<details open class="mb-2">
 			<summary class="text-xl font-semibold dark:text-neutral-300">{name}</summary>
 			{#each actions as action}
-				<div class="flex flex-row items-center my-2 space-x-2">
+				<div
+					class="flex flex-row items-center my-2 space-x-2"
+					role="group"
+					draggable="true"
+					on:dragstart={(event) => event.dataTransfer?.setData("action", JSON.stringify(action))}
+				>
 					<img
 						src={!action.icon.startsWith("opendeck/") ? "http://localhost:57118/" + action.icon : action.icon.replace("opendeck", "")}
 						alt={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
 						class="w-12 h-12 rounded-xs"
-						draggable="true"
-						on:dragstart={(event) => event.dataTransfer?.setData("action", JSON.stringify(action))}
 					/>
 					<span class="dark:text-neutral-400">{$localisations?.[action.plugin]?.[action.uuid]?.Name ?? action.name}</span>
 				</div>


### PR DESCRIPTION
This pull request fixes some bugs related to dragging actions out of the action list
 - Makes the entire action draggable, not just the action image
 - Prevents the action category name from being selected, which eliminates visual bugs when dragging
 
 Before:
![opendeck_VoDj2snrNh](https://github.com/user-attachments/assets/40d99c60-6fef-4dd0-af34-880b77bf8931)

 After:
![opendeck_WEt195y9Lm](https://github.com/user-attachments/assets/f157fd1f-fd65-47dc-8154-c39445a0cfa9)
