### PR TITLE
Implement the `applicationDidLaunch` and `applicationDidTerminate` events

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2864,6 +2864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3068,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,6 +3202,7 @@ dependencies = [
  "serde-inline-default",
  "serde_json",
  "serde_with",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-aptabase",
@@ -4750,6 +4770,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,9 +47,9 @@ base64 = "0.22"
 reqwest = "0.12"
 zip = { version = "4.0", default-features = false, features = ["deflate", "zstd"] }
 active-win-pos-rs = "0.9"
+sysinfo = "0.36"
 semver = "1.0"
 path-slash = "0.2"
-sysinfo = "0.36.1"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ zip = { version = "4.0", default-features = false, features = ["deflate", "zstd"
 active-win-pos-rs = "0.9"
 semver = "1.0"
 path-slash = "0.2"
+sysinfo = "0.36.1"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/application_watcher.rs
+++ b/src-tauri/src/application_watcher.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use active_win_pos_rs::get_active_window;
 use once_cell::sync::Lazy;
-use sysinfo::{Pid, ProcessRefreshKind, System};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::{Emitter, Manager};
 use tokio::sync::RwLock;
 
@@ -70,7 +70,7 @@ pub fn init_application_watcher() {
 		let mut system = System::new_all();
 
 		loop {
-			system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
+			system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
 
 			for (application, processes) in APPLICATION_PROCESSES.write().await.iter_mut() {
 				let mut alive_processes = Vec::with_capacity(processes.len());

--- a/src-tauri/src/application_watcher.rs
+++ b/src-tauri/src/application_watcher.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use active_win_pos_rs::get_active_window;
 use once_cell::sync::Lazy;
+use sysinfo::{Pid, ProcessRefreshKind, System};
 use tauri::{Emitter, Manager};
 use tokio::sync::RwLock;
 
@@ -12,6 +13,9 @@ impl NotProfile for ApplicationProfiles {}
 
 pub static APPLICATIONS: RwLock<Vec<String>> = RwLock::const_new(Vec::new());
 pub static APPLICATION_PROFILES: Lazy<RwLock<Store<ApplicationProfiles>>> = Lazy::new(|| RwLock::const_new(Store::new("applications", &crate::shared::config_dir(), HashMap::new()).unwrap()));
+
+pub static MONITORED_PROCESSES: Lazy<RwLock<HashMap<String, Vec<u32>>>> = Lazy::new(|| RwLock::const_new(HashMap::new()));
+pub static MONITORED_APPLICATIONS: Lazy<RwLock<HashMap<String, Vec<String>>>> = Lazy::new(|| RwLock::const_new(HashMap::new()));
 
 #[derive(Clone, serde::Serialize)]
 pub struct SwitchProfileEvent {
@@ -61,4 +65,88 @@ pub fn init_application_watcher() {
 			tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 		}
 	});
+
+	tokio::spawn(async move {
+		log::debug!("Starting application monitor...");
+		let mut system = System::new_all();
+
+		loop {
+			system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, ProcessRefreshKind::everything().without_tasks());
+
+			// Check for terminated processes
+			for (app_name, processes) in MONITORED_PROCESSES.write().await.iter_mut() {
+				let mut new_processes = Vec::with_capacity(processes.len());
+				for pid in processes.iter() {
+					if system.process(Pid::from_u32(*pid)).is_some() {
+						new_processes.push(*pid);
+						continue;
+					}
+
+					log::debug!("Process {} with PID {} has terminated", app_name, pid);
+					for plugin in MONITORED_APPLICATIONS.read().await.get(app_name).into_iter().flatten() {
+						let _ = crate::events::outbound::app_monitor::application_did_terminate(plugin, app_name.clone()).await;
+					}
+				}
+				*processes = new_processes;
+			}
+
+			// Check for new processes
+			let monitoring_plugins = MONITORED_APPLICATIONS.read().await;
+			for (app_name, plugins) in &*monitoring_plugins {
+				for process in system.processes_by_exact_name(app_name.as_ref()) {
+					let pid = process.pid().as_u32();
+
+					let mut monitored_apps = MONITORED_PROCESSES.write().await;
+					let pids = monitored_apps.entry(app_name.clone()).or_default();
+					if !pids.contains(&pid) {
+						log::debug!("Found new process: {} with PID {}", &app_name, pid);
+						pids.push(pid);
+
+						for plugin in plugins {
+							let _ = crate::events::outbound::app_monitor::application_did_launch(plugin, app_name.to_string()).await;
+						}
+					}
+				}
+			}
+
+			tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+		}
+	});
+}
+
+pub async fn start_monitoring(plugin: &str, application: &str) -> Result<(), anyhow::Error> {
+	let mut plugins = MONITORED_APPLICATIONS.write().await;
+	plugins.entry(application.to_owned()).or_default().push(plugin.to_owned());
+	drop(plugins);
+
+	let monitored_apps = MONITORED_PROCESSES.read().await;
+	if let Some(pids) = monitored_apps.get(application) {
+		for _ in 0..pids.len() {
+			let _ = crate::events::outbound::app_monitor::application_did_launch(plugin, application.to_owned()).await;
+		}
+	}
+	log::debug!("{} is now being monitored by {}", application, plugin);
+	Ok(())
+}
+
+pub async fn stop_monitoring_all(plugin: &str) -> Result<(), anyhow::Error> {
+	let plugins = MONITORED_APPLICATIONS.read().await;
+	for (application, plugins) in &*plugins {
+		if plugins.contains(&plugin.to_string()) {
+			stop_monitoring(plugin, application).await?;
+		}
+	}
+	Ok(())
+}
+
+pub async fn stop_monitoring(plugin: &str, application: &str) -> Result<(), anyhow::Error> {
+	let mut plugins = MONITORED_APPLICATIONS.write().await;
+	let entry = plugins.entry(application.to_owned()).or_default();
+	entry.retain(|p| p != plugin);
+
+	if entry.is_empty() {
+		MONITORED_PROCESSES.write().await.remove(application);
+	}
+	log::debug!("{} is no longer being monitored by {}", application, plugin);
+	Ok(())
 }

--- a/src-tauri/src/application_watcher.rs
+++ b/src-tauri/src/application_watcher.rs
@@ -12,10 +12,10 @@ pub type ApplicationProfiles = HashMap<String, HashMap<String, String>>;
 impl NotProfile for ApplicationProfiles {}
 
 pub static APPLICATIONS: RwLock<Vec<String>> = RwLock::const_new(Vec::new());
-pub static APPLICATION_PROFILES: Lazy<RwLock<Store<ApplicationProfiles>>> = Lazy::new(|| RwLock::const_new(Store::new("applications", &crate::shared::config_dir(), HashMap::new()).unwrap()));
+pub static APPLICATION_PROFILES: Lazy<RwLock<Store<ApplicationProfiles>>> = Lazy::new(|| RwLock::new(Store::new("applications", &crate::shared::config_dir(), HashMap::new()).unwrap()));
 
-pub static MONITORED_PROCESSES: Lazy<RwLock<HashMap<String, Vec<u32>>>> = Lazy::new(|| RwLock::const_new(HashMap::new()));
-pub static MONITORED_APPLICATIONS: Lazy<RwLock<HashMap<String, Vec<String>>>> = Lazy::new(|| RwLock::const_new(HashMap::new()));
+pub static APPLICATION_PROCESSES: Lazy<RwLock<HashMap<String, Vec<u32>>>> = Lazy::new(|| RwLock::new(HashMap::new()));
+pub static APPLICATION_PLUGINS: Lazy<RwLock<HashMap<String, Vec<String>>>> = Lazy::new(|| RwLock::new(HashMap::new()));
 
 #[derive(Clone, serde::Serialize)]
 pub struct SwitchProfileEvent {
@@ -67,43 +67,35 @@ pub fn init_application_watcher() {
 	});
 
 	tokio::spawn(async move {
-		log::debug!("Starting application monitor...");
 		let mut system = System::new_all();
 
 		loop {
-			system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, ProcessRefreshKind::everything().without_tasks());
+			system.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
 
-			// Check for terminated processes
-			for (app_name, processes) in MONITORED_PROCESSES.write().await.iter_mut() {
-				let mut new_processes = Vec::with_capacity(processes.len());
+			for (application, processes) in APPLICATION_PROCESSES.write().await.iter_mut() {
+				let mut alive_processes = Vec::with_capacity(processes.len());
 				for pid in processes.iter() {
 					if system.process(Pid::from_u32(*pid)).is_some() {
-						new_processes.push(*pid);
-						continue;
-					}
-
-					log::debug!("Process {} with PID {} has terminated", app_name, pid);
-					for plugin in MONITORED_APPLICATIONS.read().await.get(app_name).into_iter().flatten() {
-						let _ = crate::events::outbound::app_monitor::application_did_terminate(plugin, app_name.clone()).await;
+						alive_processes.push(*pid);
+					} else {
+						for plugin in APPLICATION_PLUGINS.read().await.get(application).into_iter().flatten() {
+							let _ = crate::events::outbound::applications::application_did_terminate(plugin, application.clone()).await;
+						}
 					}
 				}
-				*processes = new_processes;
+				*processes = alive_processes;
 			}
 
-			// Check for new processes
-			let monitoring_plugins = MONITORED_APPLICATIONS.read().await;
-			for (app_name, plugins) in &*monitoring_plugins {
-				for process in system.processes_by_exact_name(app_name.as_ref()) {
+			let application_plugins = APPLICATION_PLUGINS.read().await;
+			for (application, plugins) in application_plugins.iter() {
+				for process in system.processes_by_exact_name(application.as_ref()) {
 					let pid = process.pid().as_u32();
-
-					let mut monitored_apps = MONITORED_PROCESSES.write().await;
-					let pids = monitored_apps.entry(app_name.clone()).or_default();
+					let mut application_processes = APPLICATION_PROCESSES.write().await;
+					let pids = application_processes.entry(application.clone()).or_default();
 					if !pids.contains(&pid) {
-						log::debug!("Found new process: {} with PID {}", &app_name, pid);
 						pids.push(pid);
-
 						for plugin in plugins {
-							let _ = crate::events::outbound::app_monitor::application_did_launch(plugin, app_name.to_string()).await;
+							let _ = crate::events::outbound::applications::application_did_launch(plugin, application.clone()).await;
 						}
 					}
 				}
@@ -114,39 +106,24 @@ pub fn init_application_watcher() {
 	});
 }
 
-pub async fn start_monitoring(plugin: &str, application: &str) -> Result<(), anyhow::Error> {
-	let mut plugins = MONITORED_APPLICATIONS.write().await;
-	plugins.entry(application.to_owned()).or_default().push(plugin.to_owned());
-	drop(plugins);
+pub async fn start_monitoring(plugin: &str, applications: &Vec<String>) {
+	let mut application_plugins = APPLICATION_PLUGINS.write().await;
 
-	let monitored_apps = MONITORED_PROCESSES.read().await;
-	if let Some(pids) = monitored_apps.get(application) {
-		for _ in 0..pids.len() {
-			let _ = crate::events::outbound::app_monitor::application_did_launch(plugin, application.to_owned()).await;
+	for application in applications {
+		application_plugins.entry(application.to_owned()).or_default().push(plugin.to_owned());
+
+		let application_processes = APPLICATION_PROCESSES.read().await;
+		if let Some(pids) = application_processes.get(application) {
+			for _ in pids {
+				let _ = crate::events::outbound::applications::application_did_launch(plugin, application.to_owned()).await;
+			}
 		}
 	}
-	log::debug!("{} is now being monitored by {}", application, plugin);
-	Ok(())
 }
 
-pub async fn stop_monitoring_all(plugin: &str) -> Result<(), anyhow::Error> {
-	let plugins = MONITORED_APPLICATIONS.read().await;
-	for (application, plugins) in &*plugins {
-		if plugins.contains(&plugin.to_string()) {
-			stop_monitoring(plugin, application).await?;
-		}
+pub async fn stop_monitoring(plugin: &str) {
+	let mut application_plugins = APPLICATION_PLUGINS.write().await;
+	for plugins in application_plugins.values_mut() {
+		plugins.retain(|p| p != plugin);
 	}
-	Ok(())
-}
-
-pub async fn stop_monitoring(plugin: &str, application: &str) -> Result<(), anyhow::Error> {
-	let mut plugins = MONITORED_APPLICATIONS.write().await;
-	let entry = plugins.entry(application.to_owned()).or_default();
-	entry.retain(|p| p != plugin);
-
-	if entry.is_empty() {
-		MONITORED_PROCESSES.write().await.remove(application);
-	}
-	log::debug!("{} is no longer being monitored by {}", application, plugin);
-	Ok(())
 }

--- a/src-tauri/src/events/outbound/app_monitor.rs
+++ b/src-tauri/src/events/outbound/app_monitor.rs
@@ -1,0 +1,40 @@
+use super::send_to_plugin;
+
+#[derive(serde::Serialize)]
+struct ApplicationDidLaunchEvent {
+	event: &'static str,
+	payload: ApplicationPayload,
+}
+
+#[derive(serde::Serialize)]
+struct ApplicationDidTerminate {
+	event: &'static str,
+	payload: ApplicationPayload,
+}
+
+#[derive(serde::Serialize)]
+struct ApplicationPayload {
+	application: String,
+}
+
+pub async fn application_did_launch(plugin: &str, application: String) -> Result<(), anyhow::Error> {
+	send_to_plugin(
+		plugin,
+		&ApplicationDidLaunchEvent {
+			event: "applicationDidLaunch",
+			payload: ApplicationPayload { application },
+		},
+	)
+	.await
+}
+
+pub async fn application_did_terminate(plugin: &str, application: String) -> Result<(), anyhow::Error> {
+	send_to_plugin(
+		plugin,
+		&ApplicationDidTerminate {
+			event: "applicationDidTerminate",
+			payload: ApplicationPayload { application },
+		},
+	)
+	.await
+}

--- a/src-tauri/src/events/outbound/applications.rs
+++ b/src-tauri/src/events/outbound/applications.rs
@@ -1,26 +1,22 @@
 use super::send_to_plugin;
 
-#[derive(serde::Serialize)]
-struct ApplicationDidLaunchEvent {
-	event: &'static str,
-	payload: ApplicationPayload,
-}
+use serde::Serialize;
 
-#[derive(serde::Serialize)]
-struct ApplicationDidTerminate {
-	event: &'static str,
-	payload: ApplicationPayload,
-}
-
-#[derive(serde::Serialize)]
+#[derive(Serialize)]
 struct ApplicationPayload {
 	application: String,
+}
+
+#[derive(Serialize)]
+struct ApplicationEvent {
+	event: &'static str,
+	payload: ApplicationPayload,
 }
 
 pub async fn application_did_launch(plugin: &str, application: String) -> Result<(), anyhow::Error> {
 	send_to_plugin(
 		plugin,
-		&ApplicationDidLaunchEvent {
+		&ApplicationEvent {
 			event: "applicationDidLaunch",
 			payload: ApplicationPayload { application },
 		},
@@ -31,7 +27,7 @@ pub async fn application_did_launch(plugin: &str, application: String) -> Result
 pub async fn application_did_terminate(plugin: &str, application: String) -> Result<(), anyhow::Error> {
 	send_to_plugin(
 		plugin,
-		&ApplicationDidTerminate {
+		&ApplicationEvent {
 			event: "applicationDidTerminate",
 			payload: ApplicationPayload { application },
 		},

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_monitor;
 pub mod devices;
 pub mod encoder;
 pub mod keypad;

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -1,4 +1,4 @@
-pub mod app_monitor;
+pub mod applications;
 pub mod devices;
 pub mod encoder;
 pub mod keypad;

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::shared::Action;
 
 use serde::Deserialize;
@@ -52,6 +54,9 @@ pub struct PluginManifest {
 
 	#[serde(alias = "DeviceNamespace")]
 	pub device_namespace: Option<String>,
+
+	#[serde(alias = "ApplicationsToMonitor")]
+	pub applications_to_monitor: Option<HashMap<String, Vec<String>>>,
 }
 
 pub fn read_manifest(base_path: &std::path::Path) -> Result<PluginManifest, anyhow::Error> {


### PR DESCRIPTION
This pull request adds a new dependency ([sysinfo](https://crates.io/crates/sysinfo)), and implements event handling for process launch and termination, which may be required for certain plugins.

It introduces two new events, `applicationDidLaunch` and `applicationDidTerminate`, which can be used by plugins to respond to the launch and termination of specific applications. For more details, refer to the [Stream Deck documentation](https://docs.elgato.com/streamdeck/sdk/guides/app-monitoring/).

Additionally, a new `ApplicationsToMonitor` property has been added to the plugin manifest, allowing plugins to specify which applications they want to monitor.

This functionality has been tested on Windows only.