### PR TITLE
fix(ui): only show actions meant to be visible

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -29,7 +29,7 @@
 				{/if}
 				<span class="ml-1">{name}</span>
 			</summary>
-			{#each actions as action}
+			{#each actions.filter((action) => action.visible_in_action_list) as action}
 				<div
 					class="flex flex-row items-center my-2 space-x-2"
 					role="group"


### PR DESCRIPTION
This PR simply makes use of the `VisibleInActionsList` property, and uses it to filter the displayed actions shown in the actionlist

Before:
<img width="250" height="605" alt="imagen" src="https://github.com/user-attachments/assets/017fbb6f-0a1e-4945-8524-417ad5a341f3" />


After:
<img width="255" height="163" alt="imagen" src="https://github.com/user-attachments/assets/c7bff797-7e81-497c-a218-4104580f0b30" />
