### PR TITLE
fix(ui): show tooltip when hovering an action

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -34,6 +34,7 @@
 					class="flex flex-row items-center my-2 space-x-2"
 					role="group"
 					draggable="true"
+					title={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
 					on:dragstart={(event) => event.dataTransfer?.setData("action", JSON.stringify(action))}
 				>
 					<img


### PR DESCRIPTION
This PR adds a `title` attribute to the whole draggable action, allowing it to display the tooltip when hovered

Before:
![opendeck_Jhjwl06OVx](https://github.com/user-attachments/assets/b3dadc06-f9d8-4c26-bd6f-d2254ea53d1a)

After:
![opendeck_Fe3nTTc9Cr](https://github.com/user-attachments/assets/000fba1f-44c1-40ef-b95f-6a6e6c0ea33e)
