### PR TITLE
feat: add search bar to actionlist

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import type { Action } from "$lib/Action";
 
+	import MagnifyingGlass from "phosphor-svelte/lib/MagnifyingGlass";
+	import XCircle from "phosphor-svelte/lib/XCircle";
+
 	import { localisations } from "$lib/settings";
 	import { PRODUCT_NAME } from "$lib/singletons";
 
 	import { invoke } from "@tauri-apps/api/core";
-	import { MagnifyingGlass, XCircle } from "phosphor-svelte";
 
 	let categories: { [name: string]: { icon?: string; actions: Action[] } } = {};
 	let plugins: any[] = [];
@@ -19,7 +21,6 @@
 	let filteredCategories: [string, { icon?: string; actions: Action[] }][] = [];
 	$: {
 		let lowerCaseQuery = query.toLowerCase().trim();
-
 		filteredCategories = Object.entries(categories)
 			.sort((a, b) => a[0] == PRODUCT_NAME ? -1 : b[0] == PRODUCT_NAME ? 1 : a[0].localeCompare(b[0]))
 			.map(([categoryName, { icon, actions }]): [string, { icon?: string; actions: Action[] }] => {
@@ -28,24 +29,21 @@
 				}
 				return [categoryName, { icon, actions }];
 			})
-			.filter(([, { actions }]) => actions.length > 0);
+			.filter(([_, { actions }]) => actions.length > 0);
 	}
 </script>
 
-<div class="searchbar flex flex-row items-center mt-1 dark:bg-neutral-700 rounded-md border-2 border-neutral-900">
-	<MagnifyingGlass size={13} class="mx-1" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+<div class="flex flex-row items-center mt-1 bg-neutral-100 dark:bg-neutral-700 border-2 dark:border-neutral-900 rounded-md">
+	<MagnifyingGlass size="13" class="ml-2 mr-1" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
 	<input
-		type="text"
-		placeholder="Search"
-		class="grow p-1 text-sm dark:text-neutral-300 invalid:text-red-400 outline-hidden"
 		bind:value={query}
+		class="w-full p-1 text-sm text-neutral-700 dark:text-neutral-300 outline-hidden"
+		placeholder="Search actions"
+		type="search"
+		spellcheck="false"
 	/>
-	<div class="relative w-0 flex items-center">
-		<button on:click={() => query = ""} class="cursor-default absolute right-0 mr-1.5" hidden={query.length == 0}>
-			<XCircle size={16} color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
-		</button>
-	</div>
 </div>
+
 <div class="grow mt-1 overflow-auto select-none">
 	{#each filteredCategories as [name, { icon, actions }]}
 		<details open class="mb-2">

--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -5,7 +5,7 @@
 	import { PRODUCT_NAME } from "$lib/singletons";
 
 	import { invoke } from "@tauri-apps/api/core";
-	import { MagnifyingGlass } from "phosphor-svelte";
+	import { MagnifyingGlass, XCircle } from "phosphor-svelte";
 
 	let categories: { [name: string]: { icon?: string; actions: Action[] } } = {};
 	let plugins: any[] = [];
@@ -37,9 +37,14 @@
 	<input
 		type="text"
 		placeholder="Search"
-		class="p-1 text-sm dark:text-neutral-300 invalid:text-red-400 outline-hidden"
+		class="grow p-1 text-sm dark:text-neutral-300 invalid:text-red-400 outline-hidden"
 		bind:value={query}
 	/>
+	<div class="relative w-0 flex items-center">
+		<button on:click={() => query = ""} class="cursor-default absolute right-0 mr-1.5" hidden={query.length == 0}>
+			<XCircle size={16} color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+		</button>
+	</div>
 </div>
 <div class="grow mt-1 overflow-auto select-none">
 	{#each filteredCategories as [name, { icon, actions }]}

--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -14,6 +14,22 @@
 		plugins = await invoke("list_plugins");
 	}
 	reload();
+
+	let query: string = "";
+	let filteredCategories: [string, { icon?: string; actions: Action[] }][] = [];
+	$: {
+		let lowerCaseQuery = query.toLowerCase().trim();
+
+		filteredCategories = Object.entries(categories)
+			.sort((a, b) => a[0] == PRODUCT_NAME ? -1 : b[0] == PRODUCT_NAME ? 1 : a[0].localeCompare(b[0]))
+			.map(([categoryName, { icon, actions }]): [string, { icon?: string; actions: Action[] }] => {
+				if (!categoryName.toLowerCase().includes(lowerCaseQuery)) {
+					actions = actions.filter((action) => action.name.toLowerCase().includes(lowerCaseQuery));
+				}
+				return [categoryName, { icon, actions }];
+			})
+			.filter(([, { actions }]) => actions.length > 0);
+	}
 </script>
 
 <div class="searchbar flex flex-row items-center mt-1 dark:bg-neutral-700 rounded-md border-2 border-neutral-900">
@@ -22,10 +38,11 @@
 		type="text"
 		placeholder="Search"
 		class="p-1 text-sm dark:text-neutral-300 invalid:text-red-400 outline-hidden"
+		bind:value={query}
 	/>
 </div>
 <div class="grow mt-1 overflow-auto select-none">
-	{#each Object.entries(categories).sort((a, b) => a[0] == PRODUCT_NAME ? -1 : b[0] == PRODUCT_NAME ? 1 : a[0].localeCompare(b[0])) as [name, { icon, actions }]}
+	{#each filteredCategories as [name, { icon, actions }]}
 		<details open class="mb-2">
 			<summary class="text-xl font-semibold dark:text-neutral-300">
 				{#if icon || (actions[0] && plugins.find((x) => x.id == actions[0].plugin) && actions.every((x) => x.plugin == actions[0].plugin))}

--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -5,6 +5,7 @@
 	import { PRODUCT_NAME } from "$lib/singletons";
 
 	import { invoke } from "@tauri-apps/api/core";
+	import { MagnifyingGlass } from "phosphor-svelte";
 
 	let categories: { [name: string]: { icon?: string; actions: Action[] } } = {};
 	let plugins: any[] = [];
@@ -15,6 +16,14 @@
 	reload();
 </script>
 
+<div class="searchbar flex flex-row items-center mt-1 dark:bg-neutral-700 rounded-md border-2 border-neutral-900">
+	<MagnifyingGlass size={13} class="mx-1" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+	<input
+		type="text"
+		placeholder="Search"
+		class="p-1 text-sm dark:text-neutral-300 invalid:text-red-400 outline-hidden"
+	/>
+</div>
 <div class="grow mt-1 overflow-auto select-none">
 	{#each Object.entries(categories).sort((a, b) => a[0] == PRODUCT_NAME ? -1 : b[0] == PRODUCT_NAME ? 1 : a[0].localeCompare(b[0])) as [name, { icon, actions }]}
 		<details open class="mb-2">

--- a/src/components/PluginManager.svelte
+++ b/src/components/PluginManager.svelte
@@ -5,6 +5,7 @@
 	import FileArrowUp from "phosphor-svelte/lib/FileArrowUp";
 	import Gear from "phosphor-svelte/lib/Gear";
 	import ListedPlugin from "./ListedPlugin.svelte";
+	import MagnifyingGlass from "phosphor-svelte/lib/MagnifyingGlass";
 	import PluginDetails from "./PluginDetails.svelte";
 	import Popup from "./Popup.svelte";
 	import Tooltip from "./Tooltip.svelte";
@@ -115,7 +116,7 @@
 	let plugins: { [id: string]: GitHubPlugin };
 	(async () => plugins = await (await fetch("https://openactionapi.github.io/plugins/catalogue.json")).json())();
 
-	let search: string = "";
+	let query: string = "";
 
 	onOpenUrl((urls: string[]) => {
 		if (!urls[0].includes("installPlugin/")) return;
@@ -197,10 +198,11 @@
 			<span class="ml-1">Install from file</span>
 		</button>
 	</div>
-	<div class="flex flex-row m-2">
+	<div class="flex flex-row items-center m-2 bg-neutral-200 dark:bg-neutral-700 rounded-md">
+		<MagnifyingGlass size="14" class="ml-3 mr-0.5" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
 		<input
-			bind:value={search}
-			class="grow p-2 dark:text-neutral-300 dark:bg-neutral-700 rounded-md outline-hidden"
+			bind:value={query}
+			class="w-full p-2 dark:text-neutral-300 outline-hidden"
 			placeholder="Search plugins"
 			type="search"
 			spellcheck="false"
@@ -230,7 +232,7 @@
 					icon="https://openactionapi.github.io/plugins/icons/{id}.png"
 					name={plugin.name}
 					subtitle={plugin.author}
-					hidden={!plugin.name.toUpperCase().includes(search.toUpperCase())}
+					hidden={!plugin.name.toLowerCase().includes(query.toLowerCase())}
 					action={() => openDetailsView = id}
 				>
 					<ArrowSquareOut
@@ -277,7 +279,7 @@
 						icon="https://plugins.amankhanna.me/icons/{plugin.id}.png"
 						name={plugin.name}
 						subtitle={plugin.author}
-						hidden={!plugin.name.toUpperCase().includes(search.toUpperCase())}
+						hidden={!plugin.name.toLowerCase().includes(query.toLowerCase())}
 						action={() => installPluginElgato(plugin)}
 					>
 						<CloudArrowDown

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 	{/if}
 </div>
 
-<div class="flex flex-col p-2 grow max-w-[18rem] h-full border-l dark:border-neutral-700">
+<div class="flex flex-col p-2 w-[18rem] h-full border-l dark:border-neutral-700">
 	{#if !$inspectedParentAction}
 		<DeviceSelector
 			bind:devices

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 	{/if}
 </div>
 
-<div class="flex flex-col p-2 w-[18rem] h-full border-l dark:border-neutral-700">
+<div class="flex flex-col p-2 grow max-w-[18rem] h-full border-l dark:border-neutral-700">
 	{#if !$inspectedParentAction}
 		<DeviceSelector
 			bind:devices


### PR DESCRIPTION
This PR implements a search bar which allows to find the desired actions faster.
- If the name of the category matches the search query, then the whole category is shown
- If the name of the action matches, it shows it
- After writing the query in the search bar, a clear button is shown

<img width="898" height="672" alt="opendeck_uupKapMSKO" src="https://github.com/user-attachments/assets/6781269b-a29d-4faf-98cd-e10804bdad56" />
<img width="898" height="672" alt="opendeck_ghVuofmhtK" src="https://github.com/user-attachments/assets/4e8a8670-0d01-4102-8e20-38b2c403f5e9" />
<img width="898" height="672" alt="opendeck_Qw5yx8xPAZ" src="https://github.com/user-attachments/assets/5fcf9572-cded-442c-8a38-cb24c9f2cb75" />

