### PR TITLE
fix(ui): adjust width of the actionlist container

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 	{/if}
 </div>
 
-<div class="flex flex-col p-2 grow max-w-[18rem] h-full border-l dark:border-neutral-700">
+<div class="flex flex-col p-2 w-[18rem] h-full border-l dark:border-neutral-700">
 	{#if !$inspectedParentAction}
 		<DeviceSelector
 			bind:devices


### PR DESCRIPTION
This PR fixes a visual bug when searching for an action/category that doesn't exist.
(cherry picked from commit 86b4d77d7a2c487695adf7fdd11f2f1a0c1ba031)

Before:
![opendeck_0Kbu0suJ3x](https://github.com/user-attachments/assets/ac47a0ab-e383-43b4-92f0-12aa4af1a4bc)

After:
![opendeck_pYCGdR4iis](https://github.com/user-attachments/assets/8e0f39f6-7164-4bdb-80b3-41364676d0f8)