### PR TITLE
fix(ui): prevent dragging only the action icon

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -69,7 +69,7 @@
 					<img
 						src={!action.icon.startsWith("opendeck/") ? "http://localhost:57118/" + action.icon : action.icon.replace("opendeck", "")}
 						alt={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
-						class="w-12 h-12 rounded-xs"
+						class="w-12 h-12 rounded-xs pointer-events-none"
 					/>
 					<span class="dark:text-neutral-400">{$localisations?.[action.plugin]?.[action.uuid]?.Name ?? action.name}</span>
 				</div>


### PR DESCRIPTION
This PR fixes a simple visual bug on which dragging from the action icon would only show the icon being dragged instead of the whole draggable action.

Before:
![opendeck_OV1H3pqx2x](https://github.com/user-attachments/assets/579f9e06-d06a-4d5d-a0fa-980633d6c36b)

After:
![opendeck_VItX7xISjX](https://github.com/user-attachments/assets/c5d4a66d-f520-489a-8965-68e5fda9f30e)
