### PR TITLE
fix: prevent socket handle inheritance on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3216,7 +3216,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "urlencoding",
- "windows 0.61.3",
+ "windows-sys 0.60.2",
  "zip",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ semver = "1.0"
 path-slash = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = "0.61.3"
+windows-sys = "0.60"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -437,10 +437,9 @@ async fn init_websocket_server() {
 	#[cfg(windows)]
 	{
 		use std::os::windows::io::AsRawSocket;
-		use windows::Win32::Foundation::{HANDLE, HANDLE_FLAG_INHERIT, SetHandleInformation};
+		use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
-		let raw_socket = HANDLE(listener.as_raw_socket() as _);
-		let _ = unsafe { SetHandleInformation(raw_socket, HANDLE_FLAG_INHERIT.0, !HANDLE_FLAG_INHERIT) };
+		unsafe { SetHandleInformation(listener.as_raw_socket() as _, HANDLE_FLAG_INHERIT, 0) };
 	}
 
 	while let Ok((stream, _)) = listener.accept().await {

--- a/src-tauri/src/plugins/webserver.rs
+++ b/src-tauri/src/plugins/webserver.rs
@@ -22,10 +22,9 @@ pub async fn init_webserver(prefix: PathBuf) {
 		#[cfg(windows)]
 		{
 			use std::os::windows::io::AsRawSocket;
-			use windows::Win32::Foundation::{HANDLE, HANDLE_FLAG_INHERIT, SetHandleInformation};
+			use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
 
-			let raw_socket = HANDLE(listener.as_raw_socket() as _);
-			let _ = unsafe { SetHandleInformation(raw_socket, HANDLE_FLAG_INHERIT.0, !HANDLE_FLAG_INHERIT) };
+			unsafe { SetHandleInformation(listener.as_raw_socket() as _, HANDLE_FLAG_INHERIT, 0) };
 		}
 
 		Server::from_listener(listener, None).unwrap()


### PR DESCRIPTION
This PR addresses an issue on Windows where forcefully killing OpenDeck would leave the socket in a `LISTENING` state, preventing OpenDeck from binding to the same port on restart. This happened because, by default, child processes inherit handles in Windows, causing the sockets to stay active even after the main process was terminated. The fix ensures that this problem no longer occurs by preventing socket inheritance.

This bug does not occur on Unix because `TcpListener` on Unix already sets the `SO_REUSEADDR` option, which allows for rebinding the same port even if a process is terminated.