### PR TITLE
fix: wait for plugins to be totally terminated

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -335,7 +335,10 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 					tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 				}
 			}
-			PluginInstance::Node(mut child) | PluginInstance::Wine(mut child) | PluginInstance::Native(mut child) => child.kill()?,
+			PluginInstance::Node(mut child) | PluginInstance::Wine(mut child) | PluginInstance::Native(mut child) => {
+				child.kill()?;
+				child.wait()?;
+			}
 		}
 		Ok(())
 	} else {


### PR DESCRIPTION
This PR ensures that deregistered plugins are properly killed. This is achieved by waiting for the plugin process to end after killed. This solves an issue when uninstalling a plugin, which could lead to an Access Denied error message.