### PR TITLE
fix: unlock INSTANCES before killing the plugin

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -326,8 +326,7 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 
 	crate::application_watcher::stop_monitoring(uuid).await;
 
-	let mut instances = INSTANCES.lock().await;
-	if let Some(instance) = instances.remove(uuid) {
+	if let Some(instance) = INSTANCES.lock().await.remove(uuid) {
 		match instance {
 			PluginInstance::Webview => {
 				if let Some(window) = app.get_webview_window(&uuid.replace('.', "_")) {


### PR DESCRIPTION
This PR solves an issue where INSTANCES would remain locked until the plugin was killed. This meant that the mutex would be locked for the entire duration of the operation. Now the lock is dropped right after the plugin instance is removed