### PR TITLE
Add keyboard and screen reader support for streamdeck keys, key context menus and the action list

### DIFF
--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -4,6 +4,9 @@
 	import { localisations } from "$lib/settings";
 
 	import { invoke } from "@tauri-apps/api/core";
+	import { createEventDispatcher } from "svelte";
+
+	const dispatch = createEventDispatcher();
 
 	let categories: { [name: string]: { icon?: string; actions: Action[] } } = {};
 	let plugins: any[] = [];
@@ -36,24 +39,32 @@
 		if (allActions.length === 0) return;
 
 		switch (event.key) {
-			case 'ArrowDown':
+			case "ArrowDown":
 				event.preventDefault();
 				focusedActionIndex = Math.min(focusedActionIndex + 1, allActions.length - 1);
-				announceToScreenReader(`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${focusedActionIndex + 1} of ${allActions.length}`);
+				announceToScreenReader(
+					`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${
+						focusedActionIndex + 1
+					} of ${allActions.length}`,
+				);
 				break;
-			case 'ArrowUp':
+			case "ArrowUp":
 				event.preventDefault();
 				focusedActionIndex = Math.max(focusedActionIndex - 1, 0);
-				announceToScreenReader(`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${focusedActionIndex + 1} of ${allActions.length}`);
+				announceToScreenReader(
+					`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${
+						focusedActionIndex + 1
+					} of ${allActions.length}`,
+				);
 				break;
-			case 'Enter':
-			case ' ':
+			case "Enter":
+			case " ":
 				event.preventDefault();
 				if (focusedActionIndex >= 0 && focusedActionIndex < allActions.length) {
 					selectAction(allActions[focusedActionIndex]);
 				}
 				break;
-			case 'Escape':
+			case "Escape":
 				event.preventDefault();
 				clearSelection();
 				break;
@@ -63,18 +74,18 @@
 	function selectAction(action: Action) {
 		selectedAction = action;
 		announceToScreenReader(`${$localisations?.[action.plugin]?.[action.uuid]?.Name ?? action.name} selected. Use arrow keys to navigate to a key and press Enter to assign this action.`);
-		
+
 		// Dispatch custom event to notify parent components
-		dispatchEvent(new CustomEvent('actionSelected', { detail: action }));
+		dispatch("actionSelected", action);
 	}
 
 	function clearSelection() {
 		selectedAction = null;
 		focusedActionIndex = -1;
-		announceToScreenReader('Action selection cleared.');
-		
+		announceToScreenReader("Action selection cleared.");
+
 		// Dispatch custom event to notify parent components
-		dispatchEvent(new CustomEvent('actionCleared'));
+		dispatch("actionCleared");
 	}
 
 	// Export function to get selected action for other components
@@ -87,16 +98,16 @@
 	}
 </script>
 
-<div 
-	class="grow mt-1 overflow-auto select-none" 
-	tabindex="0" 
-	role="listbox" 
+<div
+	class="grow mt-1 overflow-auto select-none"
+	tabindex="0"
+	role="listbox"
 	aria-label="Available actions. Use arrow keys to navigate, Enter or Space to select an action, then navigate to a key to assign it."
 	on:keydown={handleKeyDown}
 >
 	<!-- Screen reader announcements -->
 	<div bind:this={announcementEl} class="sr-only" aria-live="polite" aria-atomic="true"></div>
-	
+
 	{#if selectedAction}
 		<div class="mb-2 p-2 bg-blue-100 dark:bg-blue-900 rounded-md border border-blue-300 dark:border-blue-700" role="status" aria-live="polite">
 			<div class="flex flex-row items-center space-x-2">
@@ -106,7 +117,7 @@
 					class="w-6 h-6 rounded-xs"
 				/>
 				<span class="text-sm font-medium dark:text-neutral-200">Selected: {$localisations?.[selectedAction.plugin]?.[selectedAction.uuid]?.Name ?? selectedAction.name}</span>
-				<button 
+				<button
 					class="ml-auto text-xs px-2 py-1 bg-neutral-200 dark:bg-neutral-700 rounded hover:bg-neutral-300 dark:hover:bg-neutral-600"
 					on:click={clearSelection}
 					aria-label="Clear action selection"
@@ -116,7 +127,7 @@
 			</div>
 		</div>
 	{/if}
-	
+
 	{#each Object.entries(categories).sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0])) as [name, { icon, actions }], categoryIndex}
 		<details open class="mb-2">
 			<summary class="text-xl font-semibold dark:text-neutral-300">
@@ -132,10 +143,10 @@
 				<span class="ml-1">{name}</span>
 			</summary>
 			{#each actions as action, actionIndex}
-				{@const globalIndex = Object.entries(categories)
-					.sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0]))
-					.slice(0, categoryIndex)
-					.reduce((sum, [_, { actions }]) => sum + actions.length, 0) + actionIndex}
+				{@const 			globalIndex = Object.entries(categories)
+				.sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0]))
+				.slice(0, categoryIndex)
+				.reduce((sum, [_, { actions }]) => sum + actions.length, 0) + actionIndex}
 				<div
 					class="flex flex-row items-center my-2 space-x-2 cursor-pointer rounded-md p-1 transition-colors"
 					class:bg-blue-100={focusedActionIndex === globalIndex}
@@ -149,6 +160,12 @@
 					title={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
 					on:dragstart={(event) => event.dataTransfer?.setData("action", JSON.stringify(action))}
 					on:click={() => selectAction(action)}
+					on:keydown={(event) => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							selectAction(action);
+						}
+					}}
 				>
 					<img
 						src={!action.icon.startsWith("opendeck/") ? "http://localhost:57118/" + action.icon : action.icon.replace("opendeck", "")}

--- a/src/components/ActionList.svelte
+++ b/src/components/ActionList.svelte
@@ -12,10 +12,112 @@
 		plugins = await invoke("list_plugins");
 	}
 	reload();
+
+	// Accessibility state for keyboard-based action assignment
+	let selectedAction: Action | null = null;
+	let focusedActionIndex: number = -1;
+	let allActions: Action[] = [];
+	let announcementEl: HTMLElement;
+
+	// Update flattened action list when categories change
+	$: {
+		allActions = Object.entries(categories)
+			.sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0]))
+			.flatMap(([_, { actions }]) => actions);
+	}
+
+	function announceToScreenReader(message: string) {
+		if (announcementEl) {
+			announcementEl.textContent = message;
+		}
+	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (allActions.length === 0) return;
+
+		switch (event.key) {
+			case 'ArrowDown':
+				event.preventDefault();
+				focusedActionIndex = Math.min(focusedActionIndex + 1, allActions.length - 1);
+				announceToScreenReader(`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${focusedActionIndex + 1} of ${allActions.length}`);
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				focusedActionIndex = Math.max(focusedActionIndex - 1, 0);
+				announceToScreenReader(`${$localisations?.[allActions[focusedActionIndex].plugin]?.[allActions[focusedActionIndex].uuid]?.Name ?? allActions[focusedActionIndex].name}. ${focusedActionIndex + 1} of ${allActions.length}`);
+				break;
+			case 'Enter':
+			case ' ':
+				event.preventDefault();
+				if (focusedActionIndex >= 0 && focusedActionIndex < allActions.length) {
+					selectAction(allActions[focusedActionIndex]);
+				}
+				break;
+			case 'Escape':
+				event.preventDefault();
+				clearSelection();
+				break;
+		}
+	}
+
+	function selectAction(action: Action) {
+		selectedAction = action;
+		announceToScreenReader(`${$localisations?.[action.plugin]?.[action.uuid]?.Name ?? action.name} selected. Use arrow keys to navigate to a key and press Enter to assign this action.`);
+		
+		// Dispatch custom event to notify parent components
+		dispatchEvent(new CustomEvent('actionSelected', { detail: action }));
+	}
+
+	function clearSelection() {
+		selectedAction = null;
+		focusedActionIndex = -1;
+		announceToScreenReader('Action selection cleared.');
+		
+		// Dispatch custom event to notify parent components
+		dispatchEvent(new CustomEvent('actionCleared'));
+	}
+
+	// Export function to get selected action for other components
+	export function getSelectedAction() {
+		return selectedAction;
+	}
+
+	export function clearSelectedAction() {
+		clearSelection();
+	}
 </script>
 
-<div class="grow mt-1 overflow-auto select-none">
-	{#each Object.entries(categories).sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0])) as [name, { icon, actions }]}
+<div 
+	class="grow mt-1 overflow-auto select-none" 
+	tabindex="0" 
+	role="listbox" 
+	aria-label="Available actions. Use arrow keys to navigate, Enter or Space to select an action, then navigate to a key to assign it."
+	on:keydown={handleKeyDown}
+>
+	<!-- Screen reader announcements -->
+	<div bind:this={announcementEl} class="sr-only" aria-live="polite" aria-atomic="true"></div>
+	
+	{#if selectedAction}
+		<div class="mb-2 p-2 bg-blue-100 dark:bg-blue-900 rounded-md border border-blue-300 dark:border-blue-700" role="status" aria-live="polite">
+			<div class="flex flex-row items-center space-x-2">
+				<img
+					src={!selectedAction.icon.startsWith("opendeck/") ? "http://localhost:57118/" + selectedAction.icon : selectedAction.icon.replace("opendeck", "")}
+					alt=""
+					class="w-6 h-6 rounded-xs"
+				/>
+				<span class="text-sm font-medium dark:text-neutral-200">Selected: {$localisations?.[selectedAction.plugin]?.[selectedAction.uuid]?.Name ?? selectedAction.name}</span>
+				<button 
+					class="ml-auto text-xs px-2 py-1 bg-neutral-200 dark:bg-neutral-700 rounded hover:bg-neutral-300 dark:hover:bg-neutral-600"
+					on:click={clearSelection}
+					aria-label="Clear action selection"
+				>
+					✕
+				</button>
+			</div>
+		</div>
+	{/if}
+	
+	{#each Object.entries(categories).sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0])) as [name, { icon, actions }], categoryIndex}
 		<details open class="mb-2">
 			<summary class="text-xl font-semibold dark:text-neutral-300">
 				{#if icon || (actions[0] && plugins.find((x) => x.id == actions[0].plugin) && actions.every((x) => x.plugin == actions[0].plugin))}
@@ -29,17 +131,28 @@
 				{/if}
 				<span class="ml-1">{name}</span>
 			</summary>
-			{#each actions as action}
+			{#each actions as action, actionIndex}
+				{@const globalIndex = Object.entries(categories)
+					.sort((a, b) => a[0] == "OpenDeck" ? -1 : b[0] == "OpenDeck" ? 1 : a[0].localeCompare(b[0]))
+					.slice(0, categoryIndex)
+					.reduce((sum, [_, { actions }]) => sum + actions.length, 0) + actionIndex}
 				<div
-					class="flex flex-row items-center my-2 space-x-2"
-					role="group"
+					class="flex flex-row items-center my-2 space-x-2 cursor-pointer rounded-md p-1 transition-colors"
+					class:bg-blue-100={focusedActionIndex === globalIndex}
+					class:dark:bg-blue-900={focusedActionIndex === globalIndex}
+					class:bg-blue-200={selectedAction === action}
+					class:dark:bg-blue-800={selectedAction === action}
+					role="option"
+					aria-selected={selectedAction === action}
+					tabindex="-1"
 					draggable="true"
 					title={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
 					on:dragstart={(event) => event.dataTransfer?.setData("action", JSON.stringify(action))}
+					on:click={() => selectAction(action)}
 				>
 					<img
 						src={!action.icon.startsWith("opendeck/") ? "http://localhost:57118/" + action.icon : action.icon.replace("opendeck", "")}
-						alt={$localisations?.[action.plugin]?.[action.uuid]?.Tooltip ?? action.tooltip}
+						alt=""
 						class="w-12 h-12 rounded-xs"
 					/>
 					<span class="dark:text-neutral-400">{$localisations?.[action.plugin]?.[action.uuid]?.Name ?? action.name}</span>
@@ -48,3 +161,16 @@
 		</details>
 	{/each}
 </div>
+
+<style>
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
+	}
+</style>

--- a/src/components/ContextMenu.svelte
+++ b/src/components/ContextMenu.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import type { ActionInstance } from "$lib/ActionInstance";
+	import type { Context } from "$lib/Context";
+	
+	import Clipboard from "phosphor-svelte/lib/Clipboard";
+	import Copy from "phosphor-svelte/lib/Copy";
+	import Pencil from "phosphor-svelte/lib/Pencil";
+	import Trash from "phosphor-svelte/lib/Trash";
+	
+	import { createEventDispatcher, onMount, tick } from "svelte";
+	
+	export let slot: ActionInstance | null;
+	// context is used in parent component Key.svelte
+	export let context: Context | null; // eslint-disable-line
+	export let x: number;
+	export let y: number;
+	
+	const dispatch = createEventDispatcher();
+	
+	let menuElement: HTMLDivElement;
+	let menuItems: HTMLButtonElement[] = [];
+	let focusedIndex = 0;
+	let previousFocus: HTMLElement | null = null;
+	
+	onMount(() => {
+		// Store the previously focused element
+		previousFocus = document.activeElement as HTMLElement;
+		
+		tick().then(() => {
+			// Focus the menu and the first item
+			if (menuElement) {
+				menuElement.focus();
+				if (menuItems[0]) {
+					menuItems[0].focus();
+				}
+			}
+		});
+		
+		// Add global escape handler
+		const handleGlobalKeydown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				close();
+			}
+		};
+		
+		document.addEventListener("keydown", handleGlobalKeydown);
+		
+		return () => {
+			document.removeEventListener("keydown", handleGlobalKeydown);
+			// Restore focus when menu closes
+			if (previousFocus) {
+				previousFocus.focus();
+			}
+		};
+	});
+	
+	function close() {
+		dispatch("close");
+		// Restore focus to the previously focused element
+		if (previousFocus) {
+			previousFocus.focus();
+		}
+	}
+	
+	function handleKeyDown(event: KeyboardEvent) {
+		event.stopPropagation();
+		
+		switch (event.key) {
+			case "ArrowDown":
+				event.preventDefault();
+				focusedIndex = (focusedIndex + 1) % menuItems.length;
+				menuItems[focusedIndex]?.focus();
+				break;
+			case "ArrowUp":
+				event.preventDefault();
+				focusedIndex = (focusedIndex - 1 + menuItems.length) % menuItems.length;
+				menuItems[focusedIndex]?.focus();
+				break;
+			case "Home":
+				event.preventDefault();
+				focusedIndex = 0;
+				menuItems[focusedIndex]?.focus();
+				break;
+			case "End":
+				event.preventDefault();
+				focusedIndex = menuItems.length - 1;
+				menuItems[focusedIndex]?.focus();
+				break;
+			case "Escape":
+				event.preventDefault();
+				close();
+				break;
+			case "Tab":
+				// Trap focus within menu
+				event.preventDefault();
+				if (event.shiftKey) {
+					focusedIndex = (focusedIndex - 1 + menuItems.length) % menuItems.length;
+				} else {
+					focusedIndex = (focusedIndex + 1) % menuItems.length;
+				}
+				menuItems[focusedIndex]?.focus();
+				break;
+		}
+	}
+	
+	function handleEdit() {
+		dispatch("edit");
+	}
+	
+	function handleCopy() {
+		dispatch("copy");
+	}
+	
+	function handlePaste() {
+		dispatch("paste");
+	}
+	
+	function handleClear() {
+		dispatch("clear");
+	}
+</script>
+
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<div
+	bind:this={menuElement}
+	class="absolute text-sm font-semibold w-32 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 border-2 dark:border-neutral-600 rounded-lg divide-y z-20"
+	style={`left: ${x}px; top: ${y}px;`}
+	role="menu"
+	aria-label="Context menu"
+	tabindex="-1"
+	on:keydown={handleKeyDown}
+	on:click|stopPropagation
+>
+	{#if !slot}
+		<button
+			bind:this={menuItems[0]}
+			class="flex flex-row p-2 w-full cursor-pointer items-center hover:bg-neutral-200 dark:hover:bg-neutral-600 focus:bg-neutral-200 dark:focus:bg-neutral-600 outline-none"
+			role="menuitem"
+			tabindex="-1"
+			on:click={handlePaste}
+		>
+			<Clipboard size="18" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+			<span class="ml-2"> Paste </span>
+		</button>
+	{:else}
+		<button
+			bind:this={menuItems[0]}
+			class="flex flex-row p-2 w-full cursor-pointer items-center hover:bg-neutral-200 dark:hover:bg-neutral-600 focus:bg-neutral-200 dark:focus:bg-neutral-600 outline-none"
+			role="menuitem"
+			tabindex="-1"
+			on:click={handleEdit}
+		>
+			<Pencil size="18" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+			<span class="ml-2"> Edit </span>
+		</button>
+		<button
+			bind:this={menuItems[1]}
+			class="flex flex-row p-2 w-full cursor-pointer items-center hover:bg-neutral-200 dark:hover:bg-neutral-600 focus:bg-neutral-200 dark:focus:bg-neutral-600 outline-none"
+			role="menuitem"
+			tabindex="-1"
+			on:click={handleCopy}
+		>
+			<Copy size="18" color={document.documentElement.classList.contains("dark") ? "#DEDDDA" : "#77767B"} />
+			<span class="ml-2"> Copy </span>
+		</button>
+		<button
+			bind:this={menuItems[2]}
+			class="flex flex-row p-2 w-full cursor-pointer items-center hover:bg-neutral-200 dark:hover:bg-neutral-600 focus:bg-neutral-200 dark:focus:bg-neutral-600 outline-none"
+			role="menuitem"
+			tabindex="-1"
+			on:click={handleClear}
+		>
+			<Trash size="18" color="#F66151" />
+			<span class="ml-2"> Delete </span>
+		</button>
+	{/if}
+</div>
+
+<!-- Click overlay to close menu when clicking outside -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div
+	class="fixed inset-0 z-10"
+	role="presentation"
+	on:click={close}
+/>

--- a/src/components/DeviceView.svelte
+++ b/src/components/DeviceView.svelte
@@ -58,26 +58,162 @@
 			profile = profile;
 		}
 	}
+
+	// Accessibility: Handle keyboard-based action assignment
+	let selectedAction: any = null;
+	let focusedKeyIndex: number = -1;
+	let allKeyContexts: Context[] = [];
+	let announcementEl: HTMLElement;
+
+	// Calculate all key contexts for keyboard navigation
+	$: {
+		allKeyContexts = [];
+		// Add keypad keys
+		for (let r = 0; r < device.rows; r++) {
+			for (let c = 0; c < device.columns; c++) {
+				allKeyContexts.push({
+					device: device.id,
+					profile: profile.id,
+					controller: "Keypad",
+					position: (r * device.columns) + c
+				});
+			}
+		}
+		// Add encoder keys
+		for (let i = 0; i < device.encoders; i++) {
+			allKeyContexts.push({
+				device: device.id,
+				profile: profile.id,
+				controller: "Encoder",
+				position: i
+			});
+		}
+	}
+
+	function announceToScreenReader(message: string) {
+		if (announcementEl) {
+			announcementEl.textContent = message;
+		}
+	}
+
+	function handleDeviceKeyDown(event: KeyboardEvent) {
+		if (allKeyContexts.length === 0) return;
+
+		switch (event.key) {
+			case 'ArrowRight':
+				event.preventDefault();
+				focusedKeyIndex = Math.min(focusedKeyIndex + 1, allKeyContexts.length - 1);
+				focusKey(focusedKeyIndex);
+				break;
+			case 'ArrowLeft':
+				event.preventDefault();
+				focusedKeyIndex = Math.max(focusedKeyIndex - 1, 0);
+				focusKey(focusedKeyIndex);
+				break;
+			case 'ArrowDown':
+				event.preventDefault();
+				let nextRow = focusedKeyIndex + device.columns;
+				if (nextRow < allKeyContexts.length) {
+					focusedKeyIndex = nextRow;
+					focusKey(focusedKeyIndex);
+				}
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				let prevRow = focusedKeyIndex - device.columns;
+				if (prevRow >= 0) {
+					focusedKeyIndex = prevRow;
+					focusKey(focusedKeyIndex);
+				}
+				break;
+		}
+	}
+
+	function focusKey(index: number) {
+		if (index >= 0 && index < allKeyContexts.length) {
+			const context = allKeyContexts[index];
+			const keyElement = document.querySelector(`canvas[aria-label*="${context.controller} ${context.position + 1}"]`);
+			if (keyElement) {
+				(keyElement as HTMLElement).focus();
+				const currentSlot = (context.controller === "Encoder" ? profile.sliders : profile.keys)[context.position];
+				const actionName = currentSlot?.action?.name || 'Empty';
+				announceToScreenReader(`${context.controller} ${context.position + 1}: ${actionName}`);
+			}
+		}
+	}
+
+	async function handleAssignAction(action: any, context: Context) {
+		if (!action || !context) return;
+
+		let array = context.controller == "Encoder" ? profile.sliders : profile.keys;
+		if (array[context.position]) {
+			announceToScreenReader('Key already has an action. Delete the current action first.');
+			return;
+		}
+
+		try {
+			array[context.position] = await invoke("create_instance", { context, action });
+			profile = profile;
+			announceToScreenReader(`${action.name} assigned to ${context.controller} ${context.position + 1}`);
+			
+			// Clear the selected action after successful assignment
+			selectedAction = null;
+			// Dispatch event to notify parent to clear action list selection
+			const clearEvent = new CustomEvent('actionCleared', { bubbles: true });
+			dispatchEvent(clearEvent);
+		} catch (error) {
+			console.error('Failed to assign action:', error);
+			announceToScreenReader('Failed to assign action. Please try again.');
+		}
+	}
+
+	// Export functions for parent component coordination
+	export function handleActionSelected(event: CustomEvent) {
+		selectedAction = event.detail;
+	}
+
+	export function handleActionCleared() {
+		selectedAction = null;
+	}
+
+	// Handle request for selected action from Key component
+	function handleRequestSelectedAction(event: CustomEvent) {
+		if (selectedAction && event.detail.context) {
+			handleAssignAction(selectedAction, event.detail.context);
+		} else if (!selectedAction) {
+			announceToScreenReader('No action selected. Select an action from the action list first.');
+		}
+	}
 </script>
 
 {#key device}
+	<!-- Screen reader announcements -->
+	<div bind:this={announcementEl} class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		class="flex flex-col"
 		class:hidden={$inspectedParentAction || selectedDevice != device.id}
+		role="grid"
+		aria-label={`${device.name} Stream Deck with ${device.rows * device.columns} keys${device.encoders > 0 ? ` and ${device.encoders} encoders` : ''}. Use arrow keys to navigate, Enter to select or assign actions.`}
+		tabindex="-1"
 		on:click={() => inspectedInstance.set(null)}
-		on:keyup={() => inspectedInstance.set(null)}
+		on:keydown={handleDeviceKeyDown}
+		on:requestSelectedAction={handleRequestSelectedAction}
 	>
-		<div class="flex flex-col">
+		<div class="flex flex-col" role="rowgroup">
 			{#each { length: device.rows } as _, r}
-				<div class="flex flex-row">
+				<div class="flex flex-row" role="row">
 					{#each { length: device.columns } as _, c}
+						{@const keyIndex = (r * device.columns) + c}
 						<Key
-							context={{ device: device.id, profile: profile.id, controller: "Keypad", position: (r * device.columns) + c }}
-							bind:inslot={profile.keys[(r * device.columns) + c]}
+							context={{ device: device.id, profile: profile.id, controller: "Keypad", position: keyIndex }}
+							bind:inslot={profile.keys[keyIndex]}
+							focused={focusedKeyIndex === keyIndex}
+							onAssignAction={(action, context) => handleAssignAction(action, context)}
 							on:dragover={handleDragOver}
-							on:drop={(event) => handleDrop(event, "Keypad", (r * device.columns) + c)}
-							on:dragstart={(event) => handleDragStart(event, "Keypad", (r * device.columns) + c)}
+							on:drop={(event) => handleDrop(event, "Keypad", keyIndex)}
+							on:dragstart={(event) => handleDragStart(event, "Keypad", keyIndex)}
 							{handlePaste}
 							size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
 						/>
@@ -86,11 +222,14 @@
 			{/each}
 		</div>
 
-		<div class="flex flex-row">
+		<div class="flex flex-row" role="rowgroup">
 			{#each { length: device.encoders } as _, i}
+				{@const encoderIndex = (device.rows * device.columns) + i}
 				<Key
 					context={{ device: device.id, profile: profile.id, controller: "Encoder", position: i }}
 					bind:inslot={profile.sliders[i]}
+					focused={focusedKeyIndex === encoderIndex}
+					onAssignAction={(action, context) => handleAssignAction(action, context)}
 					on:dragover={handleDragOver}
 					on:drop={(event) => handleDrop(event, "Encoder", i)}
 					on:dragstart={(event) => handleDragStart(event, "Encoder", i)}
@@ -101,3 +240,16 @@
 		</div>
 	</div>
 {/key}
+
+<style>
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
+	}
+</style>

--- a/src/components/InstanceEditor.svelte
+++ b/src/components/InstanceEditor.svelte
@@ -14,13 +14,24 @@
 
 	let fileInput: HTMLInputElement;
 	let colourInput: HTMLInputElement;
+	let errorMessage: string = "";
+	let announcementEl: HTMLElement;
 
 	function update(instance: ActionInstance) {
 		bold = instance.states[state].style.includes("Bold");
 		italic = instance.states[state].style.includes("Italic");
 	}
 	$: update(instance);
-	$: invoke("set_state", { instance, state });
+	$: invoke("set_state", { instance, state }).catch((error) => {
+		errorMessage = `Failed to set state: ${error}`;
+		announceToScreenReader(errorMessage);
+	});
+
+	function announceToScreenReader(message: string) {
+		if (announcementEl) {
+			announcementEl.textContent = message;
+		}
+	}
 </script>
 
 <svelte:window
@@ -29,7 +40,15 @@
 	}}
 />
 
-<div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-2 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 border-2 dark:border-neutral-600 rounded-lg z-10">
+<!-- Screen reader announcements -->
+<div bind:this={announcementEl} class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
+<div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-2 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700 border-2 dark:border-neutral-600 rounded-lg z-10" role="dialog" aria-label="Edit action instance">
+	{#if errorMessage}
+		<div class="text-red-500 text-sm mb-2" role="alert">
+			{errorMessage}
+		</div>
+	{/if}
 	<div class="flex flex-row">
 		<div class="select-wrapper m-1 w-full">
 			<select class="w-full" bind:value={state}>
@@ -74,9 +93,21 @@
 				reader.onload = async () => {
 					let result = reader.result?.toString();
 					if (result) {
-						let resized = await resizeImage(result);
-						if (resized) instance.states[state].image = resized;
-						else instance.states[state].image = result;
+						try {
+							let resized = await resizeImage(result);
+							if (resized) {
+								instance.states[state].image = resized;
+								errorMessage = "";
+								announceToScreenReader("Image updated successfully.");
+							} else {
+								instance.states[state].image = result;
+								errorMessage = "";
+								announceToScreenReader("Image updated successfully.");
+							}
+						} catch (error) {
+							errorMessage = `Failed to process image: ${error}`;
+							announceToScreenReader(errorMessage);
+						}
 					}
 				};
 
@@ -93,10 +124,16 @@
 				canvas.width = 1;
 				canvas.height = 1;
 				const context = canvas.getContext("2d");
-				if (!context) return;
+				if (!context) {
+					errorMessage = "Failed to create color image.";
+					announceToScreenReader(errorMessage);
+					return;
+				}
 				context.fillStyle = colourInput.value;
 				context.fillRect(0, 0, canvas.width, canvas.height);
 				instance.states[state].image = canvas.toDataURL("image/png");
+				errorMessage = "";
+				announceToScreenReader("Solid color applied successfully.");
 			}}
 		/>
 
@@ -182,3 +219,16 @@
 		</div>
 	</div>
 </div>
+
+<style>
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
+	}
+</style>


### PR DESCRIPTION
Let me preface this by saying I'm no ninja coder, I'm a developer mostly well-versed in accessibility. There may very well be better ways to do some of the things I do in this PR and if you'd rather I just maintain my own fork that's fine, I just wanted to make sure people had a way to use these devices if they use a keyboard or a screenreader, as right now they don't.

This pull request:

- Allows for arrow-key-navigation within the key grid as well as the action list
- Pressing enter on an action in the action list stores the action, pressing enter on a key associates the action with that key. Pressing enter again on the same key opens the editor.
- Pressing f10, or the applications key on a WIndows/Linux? machine opens the context menu, suspends key code propagation to the keys and routes focus to the menu so it can be used with the arrow keys and enter key.
- Delete on a key clears it, and ctrl+c and ctrl+v should work for copying actions from one key to another.
- I think I made sure to visually indicate what key has keyboard focus visually but I can't really verify that (blind myself, heh)
The PR SHOULD pass all linting and formatter checks, I ran them several times throughout my edits.
I'm going to allow edits by maintainers in case things aren't up to the standards of the project :-)