### PR TITLE
Elgato StreamDeck Neo Touch Button Support

### DIFF
--- a/src-tauri/src/events/frontend/instances.rs
+++ b/src-tauri/src/events/frontend/instances.rs
@@ -8,7 +8,9 @@ use tokio::fs::remove_dir_all;
 
 #[command]
 pub async fn create_instance(app: AppHandle, action: Action, context: Context) -> Result<Option<ActionInstance>, Error> {
-	if !action.controllers.contains(&context.controller) {
+	// TouchPoint should be treated like Keypad for controller compatibility
+	let controller_type = if context.controller == "TouchPoint" { "Keypad" } else { &context.controller };
+	if !action.controllers.contains(&controller_type.to_string()) {
 		return Ok(None);
 	}
 
@@ -78,7 +80,11 @@ fn instance_images_dir(context: &ActionContext) -> std::path::PathBuf {
 
 #[command]
 pub async fn move_instance(source: Context, destination: Context, retain: bool) -> Result<Option<ActionInstance>, Error> {
-	if source.controller != destination.controller {
+	// Allow moving between Keypad and TouchPoint since they're compatible
+	let src_type = if source.controller == "TouchPoint" { "Keypad" } else { source.controller.as_str() };
+	let dst_type = if destination.controller == "TouchPoint" { "Keypad" } else { destination.controller.as_str() };
+	
+	if src_type != dst_type {
 		return Ok(None);
 	}
 

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -35,7 +35,7 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 
 	if selected_profile != id {
 		let old_profile = &locks.profile_stores.get_profile_store(&DEVICES.get(&device).unwrap(), &selected_profile)?.value;
-		for instance in old_profile.keys.iter().flatten().chain(&mut old_profile.sliders.iter().flatten()) {
+		for instance in old_profile.keys.iter().flatten().chain(&mut old_profile.sliders.iter().flatten()).chain(&mut old_profile.touchpoints.iter().flatten()) {
 			if !matches!(instance.action.uuid.as_str(), "opendeck.multiaction" | "opendeck.toggleaction") {
 				let _ = crate::events::outbound::will_appear::will_disappear(instance, false).await;
 			} else {
@@ -50,7 +50,7 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	// We must use the mutable version of get_profile_store in order to create the store if it does not exist.
 	let store = locks.profile_stores.get_profile_store_mut(&DEVICES.get(&device).unwrap(), &id).await?;
 	let new_profile = &store.value;
-	for instance in new_profile.keys.iter().flatten().chain(&mut new_profile.sliders.iter().flatten()) {
+	for instance in new_profile.keys.iter().flatten().chain(&mut new_profile.sliders.iter().flatten()).chain(&mut new_profile.touchpoints.iter().flatten()) {
 		if !matches!(instance.action.uuid.as_str(), "opendeck.multiaction" | "opendeck.toggleaction") {
 			let _ = crate::events::outbound::will_appear::will_appear(instance).await;
 		} else {

--- a/src-tauri/src/events/inbound/devices.rs
+++ b/src-tauri/src/events/inbound/devices.rs
@@ -26,7 +26,7 @@ pub async fn register_device(uuid: &str, mut event: PayloadEvent<crate::shared::
 		let mut locks = crate::store::profiles::acquire_locks_mut().await;
 		let selected_profile = locks.device_stores.get_selected_profile(&event.payload.id)?;
 		let profile = locks.profile_stores.get_profile_store(&DEVICES.get(&event.payload.id).unwrap(), &selected_profile)?;
-		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()) {
+		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()).chain(profile.value.touchpoints.iter().flatten()) {
 			let _ = crate::events::outbound::will_appear::will_appear(instance).await;
 		}
 
@@ -52,7 +52,7 @@ pub async fn deregister_device(uuid: &str, event: PayloadEvent<String>) -> Resul
 
 		let selected_profile = locks.device_stores.get_selected_profile(&event.payload)?;
 		let profile = locks.profile_stores.get_profile_store(&DEVICES.get(&event.payload).unwrap(), &selected_profile)?;
-		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()) {
+		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()).chain(profile.value.touchpoints.iter().flatten()) {
 			let _ = crate::events::outbound::will_appear::will_disappear(instance, false).await;
 		}
 

--- a/src-tauri/src/events/outbound/keypad.rs
+++ b/src-tauri/src/events/outbound/keypad.rs
@@ -161,3 +161,148 @@ pub async fn key_up(device: &str, key: u8) -> Result<(), anyhow::Error> {
 
 	Ok(())
 }
+
+pub async fn touchpoint_down(device: &str, point: u8) -> Result<(), anyhow::Error> {
+	let mut locks = acquire_locks_mut().await;
+	let selected_profile = locks.device_stores.get_selected_profile(device)?;
+	let context = Context {
+		device: device.to_owned(),
+		profile: selected_profile.to_owned(),
+		controller: "TouchPoint".to_owned(),
+		position: point,
+	};
+
+	let _ = key_moved(crate::APP_HANDLE.get().unwrap(), context.clone(), true).await;
+
+	let Some(instance) = get_slot_mut(&context, &mut locks).await? else { return Ok(()) };
+	if instance.action.uuid == "opendeck.multiaction" {
+		for child in instance.children.as_mut().unwrap() {
+			send_to_plugin(
+				&child.action.plugin,
+				&KeyEvent {
+					event: "keyDown",
+					action: child.action.uuid.clone(),
+					context: child.context.clone(),
+					device: child.context.device.clone(),
+					payload: GenericInstancePayload::new(child),
+				},
+			)
+			.await?;
+
+			tokio::time::sleep(Duration::from_millis(100)).await;
+
+			if child.states.len() == 2 && !child.action.disable_automatic_states {
+				child.current_state = (child.current_state + 1) % (child.states.len() as u16);
+			}
+
+			send_to_plugin(
+				&child.action.plugin,
+				&KeyEvent {
+					event: "keyUp",
+					action: child.action.uuid.clone(),
+					context: child.context.clone(),
+					device: child.context.device.clone(),
+					payload: GenericInstancePayload::new(child),
+				},
+			)
+			.await?;
+
+			tokio::time::sleep(Duration::from_millis(100)).await;
+		}
+
+		let contexts = instance.children.as_ref().unwrap().iter().map(|x| x.context.clone()).collect::<Vec<_>>();
+		for child in contexts {
+			let _ = update_state(crate::APP_HANDLE.get().unwrap(), child, &mut locks).await;
+		}
+
+		save_profile(device, &mut locks).await?;
+	} else if instance.action.uuid == "opendeck.toggleaction" {
+		let children = instance.children.as_ref().unwrap();
+		if children.is_empty() {
+			return Ok(());
+		}
+		let child = &children[instance.current_state as usize];
+		send_to_plugin(
+			&child.action.plugin,
+			&KeyEvent {
+				event: "keyDown",
+				action: child.action.uuid.clone(),
+				context: child.context.clone(),
+				device: child.context.device.clone(),
+				payload: GenericInstancePayload::new(child),
+			},
+		)
+		.await?;
+	} else {
+		send_to_plugin(
+			&instance.action.plugin,
+			&KeyEvent {
+				event: "keyDown",
+				action: instance.action.uuid.clone(),
+				context: instance.context.clone(),
+				device: instance.context.device.clone(),
+				payload: GenericInstancePayload::new(instance),
+			},
+		)
+		.await?;
+	}
+
+	Ok(())
+}
+
+pub async fn touchpoint_up(device: &str, point: u8) -> Result<(), anyhow::Error> {
+	let mut locks = acquire_locks_mut().await;
+	let selected_profile = locks.device_stores.get_selected_profile(device)?;
+	let context = Context {
+		device: device.to_owned(),
+		profile: selected_profile.to_owned(),
+		controller: "TouchPoint".to_owned(),
+		position: point,
+	};
+
+	let _ = key_moved(crate::APP_HANDLE.get().unwrap(), context.clone(), false).await;
+
+	let slot = get_slot_mut(&context, &mut locks).await?;
+	let Some(instance) = slot else { return Ok(()) };
+
+	if instance.action.uuid == "opendeck.toggleaction" {
+		let index = instance.current_state as usize;
+		let children = instance.children.as_ref().unwrap();
+		if children.is_empty() {
+			return Ok(());
+		}
+		let child = &children[index];
+		send_to_plugin(
+			&child.action.plugin,
+			&KeyEvent {
+				event: "keyUp",
+				action: child.action.uuid.clone(),
+				context: child.context.clone(),
+				device: child.context.device.clone(),
+				payload: GenericInstancePayload::new(child),
+			},
+		)
+		.await?;
+		instance.current_state = ((index + 1) % instance.children.as_ref().unwrap().len()) as u16;
+	} else if instance.action.uuid != "opendeck.multiaction" {
+		if instance.states.len() == 2 && !instance.action.disable_automatic_states {
+			instance.current_state = (instance.current_state + 1) % (instance.states.len() as u16);
+		}
+		send_to_plugin(
+			&instance.action.plugin,
+			&KeyEvent {
+				event: "keyUp",
+				action: instance.action.uuid.clone(),
+				context: instance.context.clone(),
+				device: instance.context.device.clone(),
+				payload: GenericInstancePayload::new(instance),
+			},
+		)
+		.await?;
+	};
+
+	let _ = update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await;
+	save_profile(device, &mut locks).await?;
+
+	Ok(())
+}

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -36,6 +36,8 @@ pub struct DeviceInfo {
 	pub rows: u8,
 	pub columns: u8,
 	pub encoders: u8,
+	#[serde_inline_default(0)]
+	pub touchpoints: u8,
 	pub r#type: u8,
 }
 
@@ -294,6 +296,7 @@ pub struct Profile {
 	pub id: String,
 	pub keys: Vec<Option<ActionInstance>>,
 	pub sliders: Vec<Option<ActionInstance>>,
+	pub touchpoints: Vec<Option<ActionInstance>>,
 }
 
 /// A map of category names to a list of actions in that category.

--- a/src-tauri/src/store/simplified_profile.rs
+++ b/src-tauri/src/store/simplified_profile.rs
@@ -190,6 +190,8 @@ impl DiskActionInstance {
 pub struct DiskProfile {
 	pub keys: Vec<Option<DiskActionInstance>>,
 	pub sliders: Vec<Option<DiskActionInstance>>,
+	#[serde(default)]
+	pub touchpoints: Vec<Option<DiskActionInstance>>,
 }
 
 impl From<&Profile> for DiskProfile {
@@ -197,6 +199,7 @@ impl From<&Profile> for DiskProfile {
 		Self {
 			keys: value.keys.clone().into_iter().map(|x| x.map(|v| v.into())).collect(),
 			sliders: value.sliders.clone().into_iter().map(|x| x.map(|v| v.into())).collect(),
+			touchpoints: value.touchpoints.clone().into_iter().map(|x| x.map(|v| v.into())).collect(),
 		}
 	}
 }
@@ -212,6 +215,7 @@ impl DiskProfile {
 			id,
 			keys: self.keys.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 			sliders: self.sliders.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
+			touchpoints: self.touchpoints.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 		}
 	}
 }

--- a/src/components/ParentActionView.svelte
+++ b/src/components/ParentActionView.svelte
@@ -12,9 +12,23 @@
 	export let profile: Profile;
 
 	let children: ActionInstance[];
-	$: children = profile.keys[$inspectedParentAction!.position]!.children!;
+	$: {
+		const array = $inspectedParentAction!.controller == "Encoder" 
+			? profile.sliders 
+			: $inspectedParentAction!.controller == "TouchPoint" 
+				? profile.touchpoints 
+				: profile.keys;
+		children = array[$inspectedParentAction!.position]!.children!;
+	}
 	let parentUuid: string;
-	$: parentUuid = profile.keys[$inspectedParentAction!.position]!.action.uuid;
+	$: {
+		const array = $inspectedParentAction!.controller == "Encoder" 
+			? profile.sliders 
+			: $inspectedParentAction!.controller == "TouchPoint" 
+				? profile.touchpoints 
+				: profile.keys;
+		parentUuid = array[$inspectedParentAction!.position]!.action.uuid;
+	}
 
 	function handleDragOver(event: DragEvent) {
 		event.preventDefault();
@@ -34,14 +48,28 @@
 				return;
 			}
 			let response: ActionInstance | null = await invoke("create_instance", { context: $inspectedParentAction, action });
-			if (response) profile.keys[$inspectedParentAction!.position]!.children = [...children, response];
+			const array = $inspectedParentAction!.controller == "Encoder" 
+				? profile.sliders 
+				: $inspectedParentAction!.controller == "TouchPoint" 
+					? profile.touchpoints 
+					: profile.keys;
+			if (response) {
+				array[$inspectedParentAction!.position]!.children = [...children, response];
+				profile = profile; // Trigger reactivity
+			}
 		}
 	}
 
 	async function removeInstance(index: number) {
 		await invoke("remove_instance", { context: children[index].context });
 		children.splice(index, 1);
-		profile.keys[$inspectedParentAction!.position]!.children = children;
+		const array = $inspectedParentAction!.controller == "Encoder" 
+			? profile.sliders 
+			: $inspectedParentAction!.controller == "TouchPoint" 
+				? profile.touchpoints 
+				: profile.keys;
+		array[$inspectedParentAction!.position]!.children = children;
+		profile = profile; // Trigger reactivity
 	}
 </script>
 

--- a/src/components/PropertyInspectorView.svelte
+++ b/src/components/PropertyInspectorView.svelte
@@ -151,7 +151,8 @@
 	$: instances = profile
 		.keys.filter(nonNull)
 		.reduce((prev, current) => prev.concat(current.children ? [current, ...current.children] : current), [] as ActionInstance[])
-		.concat(profile.sliders.filter(nonNull));
+		.concat(profile.sliders.filter(nonNull))
+		.concat(profile.touchpoints.filter(nonNull));
 </script>
 
 <svelte:window

--- a/src/lib/DeviceInfo.ts
+++ b/src/lib/DeviceInfo.ts
@@ -4,5 +4,6 @@ export type DeviceInfo = {
 	rows: number;
 	columns: number;
 	encoders: number;
+	touchpoints: number;
 	type: number;
 };

--- a/src/lib/Profile.ts
+++ b/src/lib/Profile.ts
@@ -5,4 +5,5 @@ export type Profile = {
 	id: string;
 	keys: (ActionInstance | null)[];
 	sliders: (ActionInstance | null)[];
+	touchpoints: (ActionInstance | null)[];
 };


### PR DESCRIPTION
# Add StreamDeck Neo Touch Button Support

This PR adds full support for the Elgato StreamDeck Neo's two touch buttons, including automatic LED colour matching based on action solid icon colour.

## Overview

The StreamDeck Neo features two touch buttons with LED strips above them. The underlying `rust-elgato-streamdeck` library already supports these touch points, but OpenDeck wasn't exposing them in the UI or handling their events. This PR integrates touch button support throughout the application.

## Changes

### Backend (Rust)

#### Core Data Structures (`src-tauri/src/shared.rs`)
- Added `touchpoints: u8` field to `DeviceInfo` to report touchpoint count
- Added `touchpoints: Vec<Option<ActionInstance>>` field to `Profile` to store touch button actions

#### Device Management (`src-tauri/src/elgato.rs`)
- Report `touchpoint_count()` when registering devices
- Handle `TouchPointDown` and `TouchPointUp` events from the device
- Implement `update_image()` for touch buttons:
  - Extract dominant colour from action icon using `extract_dominant_colour()`
  - Set LED strip colour via `set_touchpoint_colour()`
  - Turn off LED when no action is assigned

#### Event Handlers (`src-tauri/src/events/outbound/keypad.rs`)
- Added `touchpoint_down()` and `touchpoint_up()` functions
- Full support for Multi Actions and Toggle Actions on touch buttons
- Touch buttons trigger the same event flow as regular keypad buttons

#### Profile Storage (`src-tauri/src/store/profiles.rs`)
- Initialize `touchpoints` array when creating profiles
- Updated `get_slot()` and `get_slot_mut()` to handle "TouchPoint" controller type
- Updated all profile iteration loops to include `touchpoints`

#### Disk Persistence (`src-tauri/src/store/simplified_profile.rs`)
- Added `touchpoints` field to `DiskProfile` with `#[serde(default)]`
- Updated serialization/deserialization to include touch button actions
- Backward compatible with existing profiles (defaults to empty array)

#### Action Management (`src-tauri/src/events/frontend/instances.rs`)
- Treat "TouchPoint" as "Keypad" for controller compatibility checks
- Allow moving/copying actions between Keypad and TouchPoint
- Actions that support "Keypad" automatically work on touch buttons

#### Device Lifecycle (`src-tauri/src/events/inbound/devices.rs`)
- Include touchpoints in `will_appear`/`will_disappear` event loops
- Ensure plugins are notified when touch button actions appear/disappear

#### Profile Switching (`src-tauri/src/events/frontend/profiles.rs`)
- Include touchpoints when switching profiles
- Call `will_appear`/`will_disappear` for touch button actions

### Frontend (TypeScript/Svelte)

#### Type Definitions
- `src/lib/DeviceInfo.ts`: Added `touchpoints: number` field
- `src/lib/Profile.ts`: Added `touchpoints: (ActionInstance | null)[]` array

#### UI Components (`src/components/DeviceView.svelte`)
- Display touch button slots below encoders
- Updated drag-and-drop logic to handle "TouchPoint" controller
- Support for drag from action list, drag between slots, and copy/paste

#### Property Inspector (`src/components/PropertyInspectorView.svelte`)
- Include `profile.touchpoints` in the instances list
- Enables property inspector for touch button actions

#### Parent Actions (`src/components/ParentActionView.svelte`)
- Fixed to access correct array based on controller type (keys/sliders/touchpoints)
- Added reactivity triggers (`profile = profile`) for immediate UI updates
- Support for adding/removing actions from Multi/Toggle Actions on touch buttons

## Features

✅ **Touch Button Display**: Two touch button slots appear below encoders in the UI  
✅ **Drag & Drop**: Full support for dragging actions to/from touch buttons  
✅ **Action Configuration**: Property inspector works for touch button actions  
✅ **Parent Actions**: Multi Actions and Toggle Actions work on touch buttons  
✅ **LED Coloring**: Automatic LED colour extraction from action solid icon colour  
✅ **Event Handling**: Touch buttons trigger keyDown/keyUp events like regular keys  
✅ **Profile Persistence**: Touch button configurations saved/loaded with profiles  
✅ **Backward Compatibility**: Existing profiles work without migration  

## Testing

Tested on StreamDeck Neo with:
- Basic actions (Run Command, etc.)
- Multi Actions with multiple children
- Toggle Actions with state cycling
- Drag & drop between regular keys and touch buttons
- Profile saving/loading
- Property inspector editing

## Technical Notes

- Touch buttons are treated as an alias for Keypad buttons for compatibility
- LED colours are calculated as the average RGB value across all pixels in the action icon
- The `#[serde(default)]` attribute ensures backward compatibility for the touchpoints field
- Touch points don't support images (hardware limitation), only LED strip colours
