### PR TITLE
feat: implement copy_instance command and update DeviceView to use it…

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -72,6 +72,7 @@ async fn main() {
 			frontend::get_applications,
 			frontend::get_application_profiles,
 			frontend::set_application_profiles,
+			frontend::instances::copy_instance,
 			frontend::instances::create_instance,
 			frontend::instances::move_instance,
 			frontend::instances::remove_instance,

--- a/src/components/DeviceView.svelte
+++ b/src/components/DeviceView.svelte
@@ -56,7 +56,7 @@
 	}
 
 	async function handlePaste(source: Context, destination: Context) {
-		let response: ActionInstance = await invoke("move_instance", { source, destination, retain: true });
+		let response: ActionInstance = await invoke("copy_instance", { source, destination });
 		if (response) {
 			(destination.controller == "Encoder" ? profile.sliders : profile.keys)[destination.position] = response;
 			profile = profile;


### PR DESCRIPTION
- Create copy_instance command
Used during copy and paste operations to improve separation of concerns, simplifying move_instance command
