### PR TITLE
feat: load font list from system installed fonts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -711,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +821,19 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
@@ -855,6 +877,18 @@ checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "19.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -1338,6 +1372,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1455,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "font-loader"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49d6b4c11dca1a1dd931a34a9f397e2da91abe3de4110505f3530a80e560b52"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-text",
+ "libc",
+ "servo-fontconfig",
+ "winapi",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1516,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3256,6 +3324,7 @@ dependencies = [
  "dashmap",
  "elgato-streamdeck",
  "fix-path-env",
+ "font-loader",
  "fs2",
  "futures",
  "image",
@@ -4672,6 +4741,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,7 @@ sysinfo = { version = "0.37", default-features = false, features = ["system"] }
 semver = "1.0"
 path-slash = "0.2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
+font-loader = "0.11"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = "0.61"

--- a/src-tauri/src/events/frontend/mod.rs
+++ b/src-tauri/src/events/frontend/mod.rs
@@ -8,6 +8,7 @@ use crate::shared::{CATEGORIES, Category, DEVICES, DeviceInfo};
 
 use std::collections::HashMap;
 
+use font_loader::system_fonts;
 use tauri::{Emitter, Manager, command};
 
 #[derive(Debug, serde_with::SerializeDisplay, serde::Deserialize)]
@@ -108,4 +109,9 @@ pub async fn set_application_profiles(value: crate::application_watcher::Applica
 	let mut store = crate::application_watcher::APPLICATION_PROFILES.write().await;
 	store.value = value;
 	Ok(store.save()?)
+}
+
+#[command]
+pub fn get_fonts() -> Vec<String> {
+	system_fonts::query_all()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -72,6 +72,7 @@ async fn main() {
 			frontend::get_applications,
 			frontend::get_application_profiles,
 			frontend::set_application_profiles,
+			frontend::get_fonts,
 			frontend::instances::create_instance,
 			frontend::instances::move_instance,
 			frontend::instances::remove_instance,

--- a/src/components/InstanceEditor.svelte
+++ b/src/components/InstanceEditor.svelte
@@ -4,6 +4,7 @@
 	import { getImage, resizeImage } from "$lib/rendererHelper";
 
 	import { invoke } from "@tauri-apps/api/core";
+	import { onMount } from "svelte";
 
 	export let instance: ActionInstance;
 	export let showEditor: boolean;
@@ -11,6 +12,11 @@
 	let state: number = 0;
 	let bold: boolean;
 	let italic: boolean;
+
+	let fonts: string[] = [];
+	onMount(async () => {
+		fonts = await invoke("get_fonts");
+	});
 
 	let fileInput: HTMLInputElement;
 	let colourInput: HTMLInputElement;
@@ -176,6 +182,10 @@
 					<option value="Liberation Serif">Liberation Serif</option>
 					<option value="Open Sans">Open Sans</option>
 					<option value="Fira Sans">Fira Sans</option>
+					<option disabled>──────────</option>
+					{#each fonts as font}
+						<option value={font}>{font}</option>
+					{/each}
 				</datalist>
 			</div>
 			<div class="flex flex-row">


### PR DESCRIPTION
Messed around with the branches on my fork and it accidentally closed the [old PR](https://github.com/nekename/OpenDeck/pull/215) so here's a new one.
> This PR works on fixing the QOL issues raised in https://github.com/nekename/OpenDeck/issues/213
> 
> For the font listing thing, I had to add a dependency called [font-loader](https://crates.io/crates/font-loader). On MacOS and Windows it seems to work just fine, on unix it needs a system dependency called "libfontconfig", which is already required by "wine" and "webkit2gtk4.1", so it shouldn't be an issue.