### PR TITLE
fix: add bounds check for state index

### DIFF
--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -27,6 +27,9 @@ pub async fn set_title(event: ContextAndPayloadEvent<SetTitlePayload>) -> Result
 
 	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
 		if let Some(state) = event.payload.state {
+			if state as usize >= instance.states.len() {
+				return Err(anyhow::anyhow!("State index out of bounds ({} > {})", state, instance.states.len() - 1));
+			}
 			instance.states[state as usize].text = event.payload.title.unwrap_or(instance.action.states[state as usize].text.clone());
 		} else {
 			for (index, state) in instance.states.iter_mut().enumerate() {
@@ -61,6 +64,9 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		}
 
 		if let Some(state) = event.payload.state {
+			if state as usize >= instance.states.len() {
+				return Err(anyhow::anyhow!("State index out of bounds ({} > {})", state, instance.states.len() - 1));
+			}
 			instance.states[state as usize].image = event.payload.image.unwrap_or(instance.action.states[state as usize].image.clone());
 		} else {
 			for (index, state) in instance.states.iter_mut().enumerate() {

--- a/src-tauri/src/events/outbound/states.rs
+++ b/src-tauri/src/events/outbound/states.rs
@@ -38,7 +38,7 @@ struct TitleParametersDidChangeEvent {
 pub async fn title_parameters_did_change(instance: &ActionInstance, state: u16) -> Result<(), anyhow::Error> {
 	let instance = instance.clone();
 	if state as usize >= instance.states.len() {
-		return Err(anyhow::anyhow!("State index out of bounds: {} >= {}", state, instance.states.len()));
+		return Err(anyhow::anyhow!("State index out of bounds ({} > {})", state, instance.states.len() - 1));
 	}
 	let state = instance.states[state as usize].clone();
 


### PR DESCRIPTION
prevents a panic @ states.rs "index out of bounds: the len is 1 but the index is 1".
