### PR TITLE
fix: initialize tray icon with a static id

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -202,7 +202,7 @@ If you have already donated, thank you so much for your support!"#,
 			let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
 			let separator = PredefinedMenuItem::separator(app)?;
 			let menu = MenuBuilder::new(app).items(&[&label, &separator, &show, &hide, &separator, &quit]).build()?;
-			let _tray = TrayIconBuilder::new()
+			let _tray = TrayIconBuilder::with_id("opendeck")
 				.menu(&menu)
 				.icon(app.default_window_icon().unwrap().clone())
 				.show_menu_on_left_click(false)


### PR DESCRIPTION
**Preflight checklist**
- [X] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [X] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [X] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [X] I will keep "Allow edits from maintainers" enabled for this pull request.

---

Initialize the tray icon with a static id, as the default has changed to deriving the id from the process id (as of [tauri-apps/tray-icons v0.21.3](https://github.com/tauri-apps/tray-icon/releases/tag/tray-icon-v0.21.3)), which breaks persistence of any configuration that relies on this id for identification (eg. tray icon visibility preferences under KDE Plasma).