### PR TITLE
Fix property inspector message handlers referencing undefined event

### DIFF
--- a/src-tauri/src/plugins/webserver.rs
+++ b/src-tauri/src/plugins/webserver.rs
@@ -80,7 +80,8 @@ pub async fn init_webserver(prefix: PathBuf) {
 					const opendeck_window_open = window.open;
 					const opendeck_iframe_container = document.getElementById("opendeck_iframe_container");
 
-					window.addEventListener("message", ({ data }) => {
+					window.addEventListener("message", (event) => {
+						const data = event.data;
 						if (data.event == "connect") {
 							event.stopImmediatePropagation();
 							if (typeof connectOpenActionSocket === "function") connectOpenActionSocket(...data.payload);
@@ -116,7 +117,8 @@ pub async fn init_webserver(prefix: PathBuf) {
 					const opendeck_window_fetch = window.fetch;
 					let opendeck_fetch_count = 0;
 					let opendeck_fetch_promises = {};
-					window.addEventListener("message", ({ data }) => {
+					window.addEventListener("message", (event) => {
+						const data = event.data;
 						if (data.event == "fetchResponse") {
 							event.stopImmediatePropagation();
 							const response = new Response(data.payload.response.body, data.payload.response);


### PR DESCRIPTION
## Summary
- The injected message handlers in the property inspector iframe destructured the `MessageEvent` parameter to just `{ data }`, but then referenced `event` for `stopImmediatePropagation()`. This caused a `ReferenceError`, preventing `connectElgatoStreamDeckSocket` from being called and leaving property inspectors stuck in a loading state.
- Changed the handlers to receive the full `event` parameter and extract `data` from it.

## Steps to reproduce
1. Install any plugin that uses `sdpi-components.js` for its property inspector (e.g. NeewerLite)
2. Add an action to the deck and click on it to open the property inspector
3. The property inspector stays stuck on "Loading..."

## Root cause
In `webserver.rs`, the two `window.addEventListener("message", ...)` handlers both destructure `({ data })` but then call `event.stopImmediatePropagation()` — since `event` is not in scope, this throws a `ReferenceError` before `connectElgatoStreamDeckSocket` can be called.

## Fix
Receive the full `event` parameter and extract `data` via `const data = event.data`.