### PR TITLE
fix(macos): prevent WKWebView from suspending plugin js

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -447,15 +447,13 @@ pub fn initialise_plugins() {
 	#[cfg(target_os = "macos")]
 	tokio::spawn(async {
 		use tauri::Manager;
+		let app = APP_HANDLE.get().unwrap();
 		loop {
 			tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 			let instances = INSTANCES.lock().await;
-			for (uuid, instance) in instances.iter() {
-				if matches!(instance, PluginInstance::Webview) {
-					let label = uuid.replace('.', "_");
-					if let Some(window) = APP_HANDLE.get().unwrap().get_webview_window(&label) {
-						let _ = window.eval("void(0)");
-					}
+			for (uuid, _) in instances.iter().filter(|(_, instance)| matches!(instance, PluginInstance::Webview)) {
+				if let Some(window) = app.get_webview_window(&uuid.replace('.', "_")) {
+					let _ = window.eval("void(0);");
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

On macOS, WKWebView windows created with `.visible(false)` have their JavaScript execution suspended by the OS after ~7 seconds as a power-saving measure. This causes all WebView-based plugins (like worldtime clock) to freeze. They stop sending WebSocket messages (SetTitle, SetImage, etc) and become completely unresponsive.

Native binary plugins are unaffected since they run as separate processes.

### Fix

A macOS-only background task that evaluates `void(0)` on each hidden WebView plugin window every 3 seconds, preventing macOS from suspending their JavaScript context. This is gated behind `#[cfg(target_os = "macos")]` so it has zero impact on Linux and Windows.

---

**Preflight checklist**
- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---
