### PR TITLE
Fix/brightness knob flicker

### DIFF
--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -16,6 +16,8 @@
 	import { invoke } from "@tauri-apps/api/core";
 	import { listen } from "@tauri-apps/api/event";
 
+	$: rotation = $settings?.rotation;
+
 	export let context: Context | null;
 	export let label: string = "";
 	export let tabindex: number = 0;
@@ -132,7 +134,7 @@
 			const unlock = await lock.lock();
 			try {
 				let fallback = sl.action.states[sl.current_state]?.image ?? sl.action.icon;
-				if (state) await renderImage(canvas, context, state, fallback, showOk, showAlert, true, active, pressed, $settings?.rotation);
+				if (state) await renderImage(canvas, context, state, fallback, showOk, showAlert, true, active, pressed, rotation);
 			} finally {
 				unlock();
 			}

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -14,9 +14,25 @@
 	let buildInfo: string;
 	(async () => buildInfo = await invoke("get_build_info"))();
 
+	let pendingBrightness: number | null = null;
+	let brightnessTimer: ReturnType<typeof setTimeout>;
+	let sliderBrightness = $settings?.brightness ?? 50;
+	$: if ($settings && pendingBrightness === null) sliderBrightness = $settings.brightness;
+	let sliderTimer: ReturnType<typeof setTimeout>;
+	function onSliderInput(e: Event) {
+		sliderBrightness = parseInt((e.target as HTMLInputElement).value);
+		clearTimeout(sliderTimer);
+		sliderTimer = setTimeout(() => {
+			if ($settings) $settings.brightness = sliderBrightness;
+		}, 50);
+	}
+	function onSliderChange() {
+		clearTimeout(sliderTimer);
+		if ($settings) $settings.brightness = sliderBrightness;
+	}
 	listen("device_brightness", ({ payload }: { payload: { action: string; value: number } }) => {
 		if (!$settings) return;
-		let value = $settings.brightness;
+		let value = pendingBrightness ?? $settings.brightness;
 		switch (payload.action) {
 			case "increase":
 				value += payload.value;
@@ -28,7 +44,15 @@
 				value = payload.value;
 				break;
 		}
-		$settings.brightness = Math.max(0, Math.min(100, value));
+		pendingBrightness = Math.max(0, Math.min(100, value));
+		clearTimeout(brightnessTimer);
+		brightnessTimer = setTimeout(() => {
+			if (pendingBrightness !== null && $settings) {
+				$settings.brightness = pendingBrightness;
+				sliderBrightness = pendingBrightness;
+				pendingBrightness = null;
+			}
+		}, 50);
 	});
 </script>
 
@@ -69,7 +93,7 @@
 
 		<div class="flex flex-row items-center m-2 space-x-2">
 			<span class="text-neutral-400"> Device brightness: </span>
-			<input type="range" min="0" max="100" bind:value={$settings.brightness} />
+			<input type="range" min="0" max="100" value={sliderBrightness} on:input={onSliderInput} on:change={onSliderChange} />
 		</div>
 
 		<div class="flex flex-row items-center m-2 space-x-2">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -19,9 +19,13 @@ import { type Writable, writable } from "svelte/store";
 export const settings: Writable<Settings | null> = writable(null);
 (async () => settings.set(await invoke("get_settings")))();
 export const localisations: Writable<{ [plugin: string]: any } | null> = writable(null);
-settings.subscribe(async (value) => {
+let debounceTimer: ReturnType<typeof setTimeout>;
+settings.subscribe((value) => {
+	clearTimeout(debounceTimer);
 	if (value) {
-		await invoke("set_settings", { settings: value });
-		localisations.set(await invoke("get_localisations", { locale: value.language }));
+		debounceTimer = setTimeout(async () => {
+			await invoke("set_settings", { settings: value });
+			localisations.set(await invoke("get_localisations", { locale: value.language }));
+		}, 100);
 	}
 });


### PR DESCRIPTION
**Preflight checklist**
- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---

fix: reduce display flicker during brightness changes using encoder knob

On the Treslin N3 using the display brightness widget on an encoder knob, and then using that knob would cause display flickering (small flashes of black in between brightness changes). Using the UI slider rapidly with the mouse did the same.

I believe the following is a valid fix that is hardware agnostic.

  ## Summary
  - Debounce settings store subscriber to avoid flooding `set_settings` on rapid changes
  - Debounce brightness slider and encoder knob inputs in SettingsView
  - Extract `$settings.rotation` in Key.svelte so brightness changes don't trigger a full re-render of every
  button

  ## Test plan
  - [x] Turn brightness encoder knob rapidly -- no flicker, device brightness updates smoothly
  - [x] Drag brightness slider in settings -- no flicker or display going black
  - [x] Knob changes reflected in settings slider position
  - [x] Slider shows correct value on app restart
  - [x] Changing display rotation still re-renders keys correctly