### PR TITLE
fix: support symlinked plugin roots

### DIFF
--- a/src-tauri/src/events/frontend/mod.rs
+++ b/src-tauri/src/events/frontend/mod.rs
@@ -77,10 +77,7 @@ pub async fn get_localisations(locale: &str) -> Result<HashMap<String, serde_jso
 	};
 
 	while let Ok(Some(entry)) = entries.next_entry().await {
-		let path = match entry.metadata().await.unwrap().is_symlink() {
-			true => tokio::fs::read_link(entry.path()).await.unwrap(),
-			false => entry.path(),
-		};
+		let path = crate::shared::plugin_entry_path(&entry.path()).unwrap_or_else(|_| entry.path());
 		let metadata = tokio::fs::metadata(&path).await.unwrap();
 		if metadata.is_dir() {
 			let Ok(locale) = tokio::fs::read(path.join(format!("{locale}.json"))).await else { continue };

--- a/src-tauri/src/events/frontend/plugins.rs
+++ b/src-tauri/src/events/frontend/plugins.rs
@@ -34,10 +34,7 @@ pub async fn list_plugins(app: AppHandle) -> Result<Vec<PluginInfo>, Error> {
 	};
 
 	while let Ok(Some(entry)) = entries.next_entry().await {
-		let path = match entry.metadata().await.unwrap().is_symlink() {
-			true => fs::read_link(entry.path()).await.unwrap(),
-			false => entry.path(),
-		};
+		let path = crate::shared::plugin_entry_path(&entry.path()).unwrap_or_else(|_| entry.path());
 		let metadata = fs::metadata(&path).await.unwrap();
 		if metadata.is_dir() {
 			let id = path.file_name().unwrap().to_str().unwrap().to_owned();

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -74,13 +74,10 @@ async fn send_to_plugin(plugin: &str, data: &impl Serialize) -> Result<(), anyho
 async fn send_to_all_plugins(data: &impl Serialize) -> Result<(), anyhow::Error> {
 	let mut entries = tokio::fs::read_dir(crate::shared::config_dir().join("plugins")).await?;
 	while let Ok(Some(entry)) = entries.next_entry().await {
-		let path = match entry.metadata().await?.is_symlink() {
-			true => tokio::fs::read_link(entry.path()).await?,
-			false => entry.path(),
-		};
+		let path = crate::shared::plugin_entry_path(&entry.path()).unwrap_or_else(|_| entry.path());
 		let metadata = tokio::fs::metadata(&path).await?;
 		if metadata.is_dir() {
-			let _ = send_to_plugin(entry.file_name().to_str().unwrap(), data).await;
+			let _ = send_to_plugin(path.file_name().unwrap().to_str().unwrap(), data).await;
 		}
 	}
 	Ok(())

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -425,10 +425,7 @@ pub fn initialise_plugins() {
 	// Iterate through all directory entries in the plugins folder and initialise them as plugins if appropriate
 	for entry in entries {
 		if let Ok(entry) = entry {
-			let path = match entry.metadata().unwrap().is_symlink() {
-				true => entry.path().parent().unwrap_or_else(|| path::Path::new(".")).join(fs::read_link(entry.path()).unwrap()),
-				false => entry.path(),
-			};
+			let path = crate::shared::plugin_entry_path(&entry.path()).unwrap_or_else(|_| entry.path());
 			let metadata = fs::metadata(&path).unwrap();
 			if metadata.is_dir() {
 				tokio::spawn(async move {

--- a/src-tauri/src/plugins/webserver.rs
+++ b/src-tauri/src/plugins/webserver.rs
@@ -14,9 +14,38 @@ fn mime(extension: &str) -> String {
 	}
 }
 
+fn is_allowed_asset_path(path: &Path, config_dir: &Path) -> bool {
+	let Ok(path) = path.canonicalize() else {
+		return false;
+	};
+
+	if path.starts_with(config_dir) {
+		return true;
+	}
+
+	let plugins_dir = config_dir.join("plugins");
+	let Ok(entries) = std::fs::read_dir(plugins_dir) else {
+		return false;
+	};
+
+	for entry in entries.flatten() {
+		let Ok(plugin_root) = crate::shared::plugin_entry_path(&entry.path()) else {
+			continue;
+		};
+		let Ok(plugin_root) = plugin_root.canonicalize() else {
+			continue;
+		};
+		if path.starts_with(plugin_root) {
+			return true;
+		}
+	}
+
+	false
+}
+
 /// Start a simple webserver to serve files of plugins that run in a browser environment.
-pub async fn init_webserver(prefix: PathBuf) {
-	let prefix = prefix.canonicalize().unwrap();
+pub async fn init_webserver(config_dir: PathBuf) {
+	let canonical_config_dir = config_dir.canonicalize().unwrap();
 	let server = {
 		let listener = std::net::TcpListener::bind(format!("0.0.0.0:{}", *super::PORT_BASE + 2)).unwrap();
 
@@ -46,11 +75,11 @@ pub async fn init_webserver(prefix: PathBuf) {
 		}
 
 		// Ensure the requested path is within the config directory to prevent unrestricted access to the filesystem.
-		let developer = match crate::store::Store::new("settings", &prefix, crate::store::Settings::default()) {
+		let developer = match crate::store::Store::new("settings", &canonical_config_dir, crate::store::Settings::default()) {
 			Ok(store) => store.value.developer,
 			Err(_) => false,
 		};
-		if !developer && !path.canonicalize().is_ok_and(|p| p.starts_with(&prefix)) {
+		if !developer && !is_allowed_asset_path(path, &canonical_config_dir) {
 			let _ = request.respond(Response::empty(403));
 			continue;
 		}

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env::var;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use serde::{Deserialize, Deserializer, Serialize, de::Visitor};
@@ -23,6 +23,23 @@ pub fn copy_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), std:
 		}
 	}
 	Ok(())
+}
+
+pub fn resolve_symlink_target(path: &Path, target: PathBuf) -> PathBuf {
+	if target.is_absolute() {
+		target
+	} else {
+		path.parent().unwrap_or_else(|| Path::new(".")).join(target)
+	}
+}
+
+pub fn plugin_entry_path(path: &Path) -> Result<PathBuf, std::io::Error> {
+	let metadata = std::fs::symlink_metadata(path)?;
+	if metadata.file_type().is_symlink() {
+		Ok(resolve_symlink_target(path, std::fs::read_link(path)?))
+	} else {
+		Ok(path.to_path_buf())
+	}
 }
 
 /// Metadata of a device.


### PR DESCRIPTION
**Preflight checklist**
- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [ ] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---
  ## Summary
  OpenDeck currently handles symlinked plugin roots inconsistently. Plugin processes can still start, but asset loading and some frontend-facing plugin discovery paths break once the plugin directory under the config folder is a symlink to a location outside that config tree.

 This change makes symlink handling consistent across plugin initialization and frontend discovery, and updates the plugin webserver to allow assets from resolved plugin roots while keeping the existing path guard in place.

  - allow plugin assets to load correctly when plugin directories in the config folder are symlinks
  - reuse a shared plugin entry path resolver across plugin initialization, frontend plugin discovery, localisation loading, and outbound plugin iteration
  - keep the webserver path guard in place while permitting files under resolved plugin roots

  ## Testing
  - cargo fmt --manifest-path src-tauri/Cargo.toml
  - cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features
  - deno check --unstable-raw-imports
  - deno task check
  - deno lint
  - launched `deno task tauri dev` and verified symlinked plugins load and register correctly

> Disclaimer: ***This PR was drafted by AI. I'm not a Rust Developer. I do not claim to fully understand the changes it's making.***