### PR TITLE
fix: skip profile save for data URI images in setImage

### DIFF
--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -1,7 +1,7 @@
 use super::Error;
 
 use crate::shared::DEVICES;
-use crate::store::profiles::{PROFILE_STORES, acquire_locks_mut, get_device_profiles};
+use crate::store::profiles::{PROFILE_SAVE_DEBOUNCE, PROFILE_STORES, acquire_locks_mut, get_device_profiles, save_profile};
 
 use tauri::{AppHandle, Emitter, Manager, command};
 
@@ -29,6 +29,12 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	let mut locks = acquire_locks_mut().await;
 	if !DEVICES.contains_key(&device) {
 		return Err(Error::new(format!("device {device} not found")));
+	}
+
+	// If a profile save is pending for this device, save it immediately to prevent losing profile data
+	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&device) {
+		handle.abort();
+		let _ = save_profile(&device, &mut locks).await;
 	}
 
 	let selected_profile = locks.device_stores.get_selected_profile(&device)?;

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -34,7 +34,9 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	// If a profile save is pending for this device, save it immediately to prevent losing profile data
 	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&device) {
 		handle.abort();
-		let _ = save_profile(&device, &mut locks).await;
+		if let Err(error) = save_profile(&device, &mut locks).await {
+			log::error!("Failed to save profile for device {device}: {error}");
+		}
 	}
 
 	let selected_profile = locks.device_stores.get_selected_profile(&device)?;

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -1,30 +1,9 @@
 use super::ContextAndPayloadEvent;
 
 use crate::events::frontend::instances::update_state;
-use crate::store::profiles::{acquire_locks_mut, get_instance_mut, save_profile};
+use crate::store::profiles::{acquire_locks_mut, debounce_profile_save, get_instance_mut, save_profile};
 
-use std::sync::LazyLock;
-
-use dashmap::DashMap;
 use serde::Deserialize;
-use tokio::task::JoinHandle;
-
-static PROFILE_SAVE_DEBOUNCE: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
-
-fn debounce_profile_save(device: String) {
-	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&device) {
-		handle.abort();
-	}
-	PROFILE_SAVE_DEBOUNCE.insert(
-		device.clone(),
-		tokio::spawn(async move {
-			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-			let mut locks = acquire_locks_mut().await;
-			let _ = save_profile(&device, &mut locks).await;
-			PROFILE_SAVE_DEBOUNCE.remove(&device);
-		}),
-	);
-}
 
 #[derive(Deserialize)]
 pub struct SetTitlePayload {

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -67,7 +67,7 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 			if state as usize >= instance.states.len() {
 				return Err(anyhow::anyhow!("State index out of bounds ({} > {})", state, instance.states.len() - 1));
 			}
-			instance.states[state as usize].image = event.payload.image.unwrap_or(instance.action.states[state as usize].image.clone());
+			instance.states[state as usize].image = event.payload.image.clone().unwrap_or(instance.action.states[state as usize].image.clone());
 		} else {
 			for (index, state) in instance.states.iter_mut().enumerate() {
 				state.image = event.payload.image.clone().unwrap_or(instance.action.states[index].image.clone());
@@ -75,7 +75,14 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		}
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	debounce_profile_save(event.context.device);
+
+	if let Some(image) = &event.payload.image
+		&& image.trim().starts_with("data:")
+	{
+		debounce_profile_save(event.context.device);
+	} else {
+		save_profile(&event.context.device, &mut locks).await?;
+	}
 
 	Ok(())
 }

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -3,26 +3,25 @@ use super::ContextAndPayloadEvent;
 use crate::events::frontend::instances::update_state;
 use crate::store::profiles::{acquire_locks_mut, get_instance_mut, save_profile};
 
-use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
 
+use dashmap::DashMap;
 use serde::Deserialize;
 use tokio::task::JoinHandle;
 
-static SAVE_DEBOUNCE: LazyLock<Mutex<HashMap<String, JoinHandle<()>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static SAVE_DEBOUNCE: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
 
 fn debounce_save_profile(device: String) {
-	let mut pending = SAVE_DEBOUNCE.lock().unwrap();
-	if let Some(handle) = pending.remove(&device) {
+	if let Some((_, handle)) = SAVE_DEBOUNCE.remove(&device) {
 		handle.abort();
 	}
-	pending.insert(
+	SAVE_DEBOUNCE.insert(
 		device.clone(),
 		tokio::spawn(async move {
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 			let mut locks = acquire_locks_mut().await;
 			let _ = save_profile(&device, &mut locks).await;
-			SAVE_DEBOUNCE.lock().unwrap().remove(&device);
+			SAVE_DEBOUNCE.remove(&device);
 		}),
 	);
 }

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -3,7 +3,29 @@ use super::ContextAndPayloadEvent;
 use crate::events::frontend::instances::update_state;
 use crate::store::profiles::{acquire_locks_mut, get_instance_mut, save_profile};
 
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
 use serde::Deserialize;
+use tokio::task::JoinHandle;
+
+static SAVE_DEBOUNCE: LazyLock<Mutex<HashMap<String, JoinHandle<()>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn debounce_save_profile(device: String) {
+	let mut pending = SAVE_DEBOUNCE.lock().unwrap();
+	if let Some(handle) = pending.remove(&device) {
+		handle.abort();
+	}
+	pending.insert(
+		device.clone(),
+		tokio::spawn(async move {
+			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+			let mut locks = acquire_locks_mut().await;
+			let _ = save_profile(&device, &mut locks).await;
+			SAVE_DEBOUNCE.lock().unwrap().remove(&device);
+		}),
+	);
+}
 
 #[derive(Deserialize)]
 pub struct SetTitlePayload {
@@ -75,7 +97,7 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		}
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	save_profile(&event.context.device, &mut locks).await?;
+	debounce_save_profile(event.context.device.clone());
 
 	Ok(())
 }

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -9,19 +9,19 @@ use dashmap::DashMap;
 use serde::Deserialize;
 use tokio::task::JoinHandle;
 
-static SAVE_DEBOUNCE: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
+static PROFILE_SAVE_DEBOUNCE: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
 
-fn debounce_save_profile(device: String) {
-	if let Some((_, handle)) = SAVE_DEBOUNCE.remove(&device) {
+fn debounce_profile_save(device: String) {
+	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&device) {
 		handle.abort();
 	}
-	SAVE_DEBOUNCE.insert(
+	PROFILE_SAVE_DEBOUNCE.insert(
 		device.clone(),
 		tokio::spawn(async move {
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 			let mut locks = acquire_locks_mut().await;
 			let _ = save_profile(&device, &mut locks).await;
-			SAVE_DEBOUNCE.remove(&device);
+			PROFILE_SAVE_DEBOUNCE.remove(&device);
 		}),
 	);
 }
@@ -96,7 +96,7 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		}
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	debounce_save_profile(event.context.device.clone());
+	debounce_profile_save(event.context.device);
 
 	Ok(())
 }

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -8,8 +8,10 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use anyhow::{Context, anyhow};
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tokio::task::JoinHandle;
 
 pub struct ProfileStores {
 	stores: HashMap<String, Store<Profile>>,
@@ -343,4 +345,20 @@ pub async fn save_profile(device: &str, locks: &mut LocksMut<'_>) -> Result<(), 
 	let device = DEVICES.get(device).unwrap();
 	let store = locks.profile_stores.get_profile_store(&device, &selected_profile)?;
 	store.save()
+}
+
+pub static PROFILE_SAVE_DEBOUNCE: LazyLock<DashMap<String, JoinHandle<()>>> = LazyLock::new(DashMap::new);
+pub fn debounce_profile_save(device: String) {
+	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&device) {
+		handle.abort();
+	}
+	PROFILE_SAVE_DEBOUNCE.insert(
+		device.clone(),
+		tokio::spawn(async move {
+			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+			let mut locks = acquire_locks_mut().await;
+			let _ = save_profile(&device, &mut locks).await;
+			PROFILE_SAVE_DEBOUNCE.remove(&device);
+		}),
+	);
 }

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -357,7 +357,9 @@ pub fn debounce_profile_save(device: String) {
 		tokio::spawn(async move {
 			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 			let mut locks = acquire_locks_mut().await;
-			let _ = save_profile(&device, &mut locks).await;
+			if let Err(error) = save_profile(&device, &mut locks).await {
+				log::error!("Failed to save profile for device {device}: {error}");
+			}
 			PROFILE_SAVE_DEBOUNCE.remove(&device);
 		}),
 	);

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -342,7 +342,7 @@ pub async fn get_instance_mut<'a>(context: &crate::shared::ActionContext, locks:
 
 pub async fn save_profile(device: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
 	let selected_profile = locks.device_stores.get_selected_profile(device)?;
-	let device = DEVICES.get(device).unwrap();
+	let device = DEVICES.get(device).ok_or_else(|| anyhow!("device not found"))?;
 	let store = locks.profile_stores.get_profile_store(&device, &selected_profile)?;
 	store.save()
 }


### PR DESCRIPTION
Plugins that update button images frequently (e.g. system monitors) send setImage with data URI payloads every second. Each call triggers save_profile(), serializing the entire profile JSON to disk — causing sustained 2-5 MB/s writes even at idle.

Data URI images are ephemeral: plugins re-push them via willAppear on startup and profile switch. Persisting them to disk is unnecessary.

This skips save_profile() when the image is a data: URI while keeping persistence for file-path images (static plugin configuration).

Fixes #249

**Preflight checklist**
- [X] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [X] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [X] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [X] I will keep "Allow edits from maintainers" enabled for this pull request.

---
