### PR TITLE
feat: per-slot disk persistence control with global default

### DIFF
--- a/src-tauri/src/events/frontend/instances.rs
+++ b/src-tauri/src/events/frontend/instances.rs
@@ -29,6 +29,7 @@ pub async fn create_instance(app: AppHandle, action: Action, context: Context) -
 			current_state: 0,
 			settings: serde_json::Value::Object(serde_json::Map::new()),
 			children: None,
+			skip_persistence: None,
 		};
 		children.push(instance.clone());
 
@@ -59,6 +60,7 @@ pub async fn create_instance(app: AppHandle, action: Action, context: Context) -
 			} else {
 				None
 			},
+			skip_persistence: None,
 		};
 
 		*slot = Some(instance.clone());
@@ -254,6 +256,24 @@ pub async fn trigger_virtual_press(context: Context) -> Result<(), Error> {
 	}
 
 	Ok(())
+}
+
+#[command]
+pub async fn toggle_skip_persistence(context: Context) -> Result<Option<bool>, Error> {
+	let mut locks = acquire_locks_mut().await;
+	let global_default = crate::store::get_settings().map(|s| s.value.skip_persistence_default).unwrap_or(false);
+	let slot = get_slot_mut(&context, &mut locks).await?;
+	if let Some(instance) = slot {
+		instance.skip_persistence = match instance.skip_persistence {
+			None => Some(!global_default),
+			Some(_) => None,
+		};
+		let new_value = instance.skip_persistence;
+		save_profile(&context.device, &mut locks).await?;
+		Ok(new_value)
+	} else {
+		Ok(None)
+	}
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -24,8 +24,12 @@ pub struct SetStatePayload {
 
 pub async fn set_title(event: ContextAndPayloadEvent<SetTitlePayload>) -> Result<(), anyhow::Error> {
 	let mut locks = acquire_locks_mut().await;
+	let mut skip = false;
 
 	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
+		let global_default = crate::store::get_settings().map(|s| s.value.skip_persistence_default).unwrap_or(false);
+		skip = instance.skip_persistence.unwrap_or(global_default);
+
 		if let Some(state) = event.payload.state {
 			if state as usize >= instance.states.len() {
 				return Err(anyhow::anyhow!("State index out of bounds ({} > {})", state, instance.states.len() - 1));
@@ -52,15 +56,21 @@ pub async fn set_title(event: ContextAndPayloadEvent<SetTitlePayload>) -> Result
 		}
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	save_profile(&event.context.device, &mut locks).await?;
+	if !skip {
+		save_profile(&event.context.device, &mut locks).await?;
+	}
 
 	Ok(())
 }
 
 pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Result<(), anyhow::Error> {
 	let mut locks = acquire_locks_mut().await;
+	let mut skip = false;
 
 	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
+		let global_default = crate::store::get_settings().map(|s| s.value.skip_persistence_default).unwrap_or(false);
+		skip = instance.skip_persistence.unwrap_or(global_default);
+
 		if let Some(image) = &event.payload.image {
 			if image.trim().is_empty() {
 				event.payload.image = None;
@@ -90,12 +100,14 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
 
-	if let Some(image) = &event.payload.image
-		&& image.trim().starts_with("data:")
-	{
-		debounce_profile_save(event.context);
-	} else {
-		save_profile(&event.context.device, &mut locks).await?;
+	if !skip {
+		if let Some(image) = &event.payload.image
+			&& image.trim().starts_with("data:")
+		{
+			debounce_profile_save(event.context);
+		} else {
+			save_profile(&event.context.device, &mut locks).await?;
+		}
 	}
 
 	Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -81,6 +81,7 @@ async fn main() {
 			frontend::instances::set_state,
 			frontend::instances::update_image,
 			frontend::instances::trigger_virtual_press,
+			frontend::instances::toggle_skip_persistence,
 			frontend::profiles::get_profiles,
 			frontend::profiles::get_selected_profile,
 			frontend::profiles::set_selected_profile,

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -305,6 +305,8 @@ pub struct ActionInstance {
 	pub current_state: u16,
 	pub settings: serde_json::Value,
 	pub children: Option<Vec<ActionInstance>>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub skip_persistence: Option<bool>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -122,6 +122,8 @@ pub struct Settings {
 	pub separatewine: bool,
 	pub developer: bool,
 	pub disableelgato: bool,
+	#[serde(default)]
+	pub skip_persistence_default: bool,
 }
 
 impl Default for Settings {
@@ -140,6 +142,7 @@ impl Default for Settings {
 			separatewine: false,
 			developer: false,
 			disableelgato: false,
+			skip_persistence_default: false,
 		}
 	}
 }

--- a/src-tauri/src/store/simplified_profile.rs
+++ b/src-tauri/src/store/simplified_profile.rs
@@ -68,6 +68,8 @@ pub struct DiskActionInstance {
 	pub current_state: u16,
 	pub settings: serde_json::Value,
 	pub children: Option<Vec<DiskActionInstance>>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub skip_persistence: Option<bool>,
 }
 
 impl From<ActionInstance> for DiskActionInstance {
@@ -133,6 +135,7 @@ impl From<ActionInstance> for DiskActionInstance {
 			current_state: value.current_state,
 			settings: value.settings,
 			children: value.children.map(|c| c.into_iter().map(|v| v.into()).collect()),
+			skip_persistence: value.skip_persistence,
 		}
 	}
 }
@@ -182,6 +185,7 @@ impl DiskActionInstance {
 			current_state: self.current_state,
 			settings: self.settings,
 			children: self.children.map(|c| c.into_iter().map(|v| v.into_action_instance(path)).collect()),
+			skip_persistence: self.skip_persistence,
 		}
 	}
 }

--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -114,6 +114,12 @@
 		$inspectedInstance = `${context.device}.${context.profile}.${context.controller}.${context.position}.0`;
 	}
 
+	async function toggleSkipPersistence() {
+		if (!slot || !context) return;
+		const newValue: boolean | null = await invoke("toggle_skip_persistence", { context });
+		slot.skip_persistence = newValue;
+	}
+
 	async function clear() {
 		$openContextMenu = null;
 		if (!slot) return;
@@ -257,12 +263,24 @@
 				<span class="ml-2"> Copy </span>
 			</button>
 			<button
-				class="flex flex-row items-center w-full p-2 hover:bg-neutral-600 transition-colors rounded-b-lg cursor-pointer"
+				class="flex flex-row items-center w-full p-2 hover:bg-neutral-600 transition-colors cursor-pointer"
 				on:click|stopPropagation={clear}
 			>
 				<Trash size="18" class="text-red-400" />
 				<span class="ml-2"> Delete </span>
 			</button>
+			<label
+				class="flex flex-row items-center w-full p-2 hover:bg-neutral-600 transition-colors rounded-b-lg cursor-pointer"
+				on:click|stopPropagation
+			>
+				<input
+					type="checkbox"
+					checked={slot.skip_persistence != null ? slot.skip_persistence : ($settings?.skip_persistence_default || false)}
+					on:change|stopPropagation={toggleSkipPersistence}
+					class="w-4 h-4 accent-blue-500 cursor-pointer"
+				/>
+				<span class="ml-2"> Skip disk writes </span>
+			</label>
 		{/if}
 	</div>
 {/if}

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -137,6 +137,14 @@
 			<input type="checkbox" bind:checked={$settings.disableelgato} id="settings-disableelgato" />
 			<Tooltip> This option disables discovery of Elgato devices so that they can be managed by other software. </Tooltip>
 		</div>
+
+		<div class="flex flex-row items-center m-2 space-x-2">
+			<label for="settings-skip_persistence_default" class="text-neutral-400">Skip image persistence by default:</label>
+			<input type="checkbox" bind:checked={$settings.skip_persistence_default} id="settings-skip_persistence_default" />
+			<Tooltip>
+				When enabled, dynamic images and titles are not written to disk by default. This reduces disk I/O for plugins that update frequently. On restart, plugins re-push their images automatically. You can override this per-slot by right-clicking any button and toggling "Skip disk writes". When disabled, all images are persisted normally and you can opt individual slots out via the same right-click menu.
+			</Tooltip>
+		</div>
 	{/if}
 
 	<div class="ml-2">


### PR DESCRIPTION
## Motivation

Plugins that update frequently (system monitors, visualisers) trigger continuous disk writes via \`save_profile\`. The existing debounce on data-URI images in \`set_image\` helps, but still writes periodically and does nothing for non-data-URI image paths or \`setTitle\`.

This complements #302 rather than replacing it: debounce still protects the common case; this adds an explicit opt-out for plugins the user knows are live-updating.

## What this adds

- **Per-slot toggle.** Right-click context menu on any assigned slot: "Skip disk writes" checkbox. Cycles \`None -> Some(!default) -> None\` so toggling twice resets to "follow global default" instead of being permanently overridden.
- **Global default.** "Skip image persistence by default" toggle in Settings. Applies to all slots unless individually overridden.
- **\`skip_persistence: Option<bool>\`** on \`ActionInstance\`. \`None\` = follow global, \`Some(true/false)\` = explicit override. Preserved through \`DiskActionInstance\` conversion so it survives restart.
- \`set_image\` and \`set_title\` check the flag and skip \`save_profile\` when set. Device still renders in real time via \`update_image\`; only disk I/O is skipped. Plugins re-push images via \`willAppear\` on restart, so skipped slots recover their visual state without persistence.

## Files

- \`src-tauri/src/shared.rs\` -- field on \`ActionInstance\`
- \`src-tauri/src/store/mod.rs\` -- global default in \`Settings\`
- \`src-tauri/src/store/simplified_profile.rs\` -- preserve flag through disk conversion
- \`src-tauri/src/events/inbound/states.rs\` -- check flag in \`set_image\` / \`set_title\`
- \`src-tauri/src/events/frontend/instances.rs\` -- \`toggle_skip_persistence\` command
- \`src-tauri/src/main.rs\` -- register command
- \`src/components/Key.svelte\` -- context menu checkbox
- \`src/components/SettingsView.svelte\` -- global default toggle