### PR TITLE
fix: protect plugin children from orphaning via PR_SET_PDEATHSIG on Linux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "hidapi",
  "image",
  "json-patch 4.1.0",
+ "libc",
  "log",
  "log-panics",
  "open",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,9 @@ path-slash = "0.2"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
 font-loader = "0.11"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = "0.61"
 

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -45,6 +45,21 @@ pub static PORT_BASE: LazyLock<u16> = LazyLock::new(|| {
 	base
 });
 
+/// Attach a kernel-enforced "die when parent dies" signal to a plugin child process.
+#[cfg(target_os = "linux")]
+fn attach_parent_death_signal(command: &mut Command) {
+	use std::os::unix::process::CommandExt;
+	// SAFETY: `libc::prctl` is async-signal-safe.
+	unsafe {
+		command.pre_exec(move || {
+			if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong) != 0 {
+				return Err(std::io::Error::last_os_error());
+			}
+			Ok(())
+		});
+	}
+}
+
 /// Initialise a plugin from a given directory.
 pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 	let plugin_uuid = path.file_name().unwrap().to_str().unwrap();
@@ -232,15 +247,18 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 
 		#[cfg(not(target_os = "windows"))]
 		{
-			let child = Command::new(command)
+			let mut command = Command::new(command);
+			command
 				.current_dir(path)
 				.args(extra_args)
 				.arg(code_path)
 				.args(args)
 				.arg(serde_json::to_string(&info)?)
 				.stdout(Stdio::from(log_file.try_clone()?))
-				.stderr(Stdio::from(log_file))
-				.spawn()?;
+				.stderr(Stdio::from(log_file));
+			#[cfg(target_os = "linux")]
+			attach_parent_death_signal(&mut command);
+			let child = command.spawn()?;
 
 			INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Node(child));
 		}
@@ -276,6 +294,8 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 		} else {
 			let _ = fs::remove_dir_all(path.join("wineprefix"));
 		}
+		#[cfg(target_os = "linux")]
+		attach_parent_death_signal(&mut command);
 		let child = command.spawn()?;
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Wine(child));
@@ -306,13 +326,16 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 
 		#[cfg(not(target_os = "windows"))]
 		{
-			let child = Command::new(path.join(code_path))
+			let mut command = Command::new(path.join(code_path));
+			command
 				.current_dir(path)
 				.args(args)
 				.arg(serde_json::to_string(&info)?)
 				.stdout(Stdio::from(log_file.try_clone()?))
-				.stderr(Stdio::from(log_file))
-				.spawn()?;
+				.stderr(Stdio::from(log_file));
+			#[cfg(target_os = "linux")]
+			attach_parent_death_signal(&mut command);
+			let child = command.spawn()?;
 
 			INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Native(child));
 		}


### PR DESCRIPTION
## Problem

When OpenDeck exits via SIGKILL, panic, or any path that doesn't run the graceful `deactivate_plugins` cleanup added in #314, plugin subprocesses aren't signaled. On Linux they reparent to PID 1 / user-systemd and keep running indefinitely — the classic orphan leak. Each orphaned plugin holds its WebSocket client (reconnecting in a loop), its polling loops, and its full heap. Across multiple OpenDeck restarts during development or instability, orphans accumulate with no bound.

Reproducing on current `main`:
```
pkill -9 opendeck          # simulate crash / force-kill
pgrep -af -- '-pluginUUID' # every previously-running plugin survives
```

## Fix

Set `PR_SET_PDEATHSIG=SIGTERM` on every plugin child via `CommandExt::pre_exec`. The kernel delivers SIGTERM to the child when its parent (this OpenDeck) dies, regardless of whether `deactivate_plugins` ran. Applied to all three non-Windows spawn sites (Node, Wine, Native).

After the fix:
```
pkill -9 opendeck
sleep 2
pgrep -af -- '-pluginUUID' # empty
```

## Relationship to #314

Complementary. #314 handles the graceful-exit case — SIGTERM delivered to each plugin via `deactivate_plugins`, with a 3-second grace window before SIGKILL. This PR handles the non-graceful-exit case — crash, panic, external SIGKILL. Together they cover both ends.

## Platform scope

Linux-only. `PR_SET_PDEATHSIG` is a Linux-specific prctl; no macOS or Windows equivalent.

- macOS: equivalent is `kqueue` with `NOTE_EXIT` on the parent PID, requires a monitor thread in each child.
- Windows: equivalent is `JobObject` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, set on the parent before spawning children.

Both are follow-up work.

## Safety

`pre_exec` runs in the forked child between `fork()` and `execve()`. Only async-signal-safe calls are permitted inside the closure. `prctl` is async-signal-safe per `signal-safety(7)`.

## Dependencies

Adds `libc = "0.2"` under a Linux-only target dep.

## Testing

Verified manually:
1. Apply patch, rebuild, install.
2. Start OpenDeck, confirm plugins spawned.
3. \`kill -9 \$(pgrep -x opendeck)\` — all plugin processes exit within 2 seconds.
4. Without the patch, same procedure leaves every plugin running as orphan.

No behavior change on macOS or Windows (helper is a no-op stub on non-Linux).