### PR TITLE
feat: activate plugins per profile, deactivate on settle

### DIFF
--- a/src-tauri/src/events/frontend/plugins.rs
+++ b/src-tauri/src/events/frontend/plugins.rs
@@ -105,14 +105,14 @@ pub async fn install_plugin(app: AppHandle, url: Option<String>, file: Option<St
 	if let Err(error) = crate::zip_extract::extract(std::io::Cursor::new(bytes), &config_dir.join("plugins")) {
 		log::error!("Failed to unzip file: {}", error);
 		let _ = fs::rename(&temp, &actual).await;
-		let _ = crate::plugins::initialise_plugin(&actual).await;
+		let _ = crate::plugins::initialise_plugin(&actual, true).await;
 		return Err(anyhow::Error::from(error).into());
 	}
-	if let Err(error) = crate::plugins::initialise_plugin(&actual).await {
+	if let Err(error) = crate::plugins::initialise_plugin(&actual, true).await {
 		log::warn!("Failed to initialise plugin at {}: {}", actual.display(), error);
 		let _ = fs::remove_dir_all(&actual).await;
 		let _ = fs::rename(&temp, &actual).await;
-		let _ = crate::plugins::initialise_plugin(&actual).await;
+		let _ = crate::plugins::initialise_plugin(&actual, true).await;
 		return Err(error.into());
 	}
 	let _ = fs::remove_dir_all(config_dir.join("temp")).await;
@@ -153,7 +153,7 @@ pub async fn remove_plugin(app: AppHandle, id: String) -> Result<(), Error> {
 #[command]
 pub async fn reload_plugin(app: AppHandle, id: String) {
 	let _ = crate::plugins::deactivate_plugin(&app, &id).await;
-	let _ = crate::plugins::initialise_plugin(&config_dir().join("plugins").join(&id)).await;
+	let _ = crate::plugins::initialise_plugin(&config_dir().join("plugins").join(&id), true).await;
 
 	let locks = acquire_locks().await;
 	let all = locks.profile_stores.all_from_plugin(&id);

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -67,6 +67,24 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	// We must use the mutable version of get_profile_store in order to create the store if it does not exist.
 	let store = locks.profile_stores.get_profile_store_mut(&DEVICES.get(&device).unwrap(), &id).await?;
 	let new_profile = &store.value;
+
+	// Lazy plugin activation: collect the plugin UUIDs referenced by the new
+	// profile and ensure each has a running subprocess before firing
+	// will_appear events. Plugins registered metadata-only at startup
+	// (unreferenced) are spawned here on first use.
+	let mut needed_plugins = std::collections::HashSet::<String>::new();
+	for instance in new_profile.keys.iter().flatten().chain(&mut new_profile.sliders.iter().flatten()) {
+		needed_plugins.insert(instance.action.plugin.clone());
+		if let Some(children) = &instance.children {
+			for child in children {
+				needed_plugins.insert(child.action.plugin.clone());
+			}
+		}
+	}
+	for uuid in &needed_plugins {
+		crate::plugins::ensure_plugin_spawned(uuid).await;
+	}
+
 	for instance in new_profile.keys.iter().flatten().chain(&mut new_profile.sliders.iter().flatten()) {
 		if !matches!(instance.action.uuid.as_str(), "opendeck.multiaction" | "opendeck.toggleaction") {
 			let _ = crate::events::outbound::will_appear::will_appear(instance).await;
@@ -79,6 +97,13 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	store.save()?;
 
 	locks.device_stores.set_selected_profile(&device, id)?;
+
+	// After a settle period, deactivate any plugin no longer needed by the
+	// current profile on this device or any other connected device. Rapid
+	// profile switching cancels and restarts the timer, so flipping through
+	// profiles does not thrash plugin processes.
+	drop(locks);
+	crate::plugins::schedule_deactivation_sweep();
 
 	Ok(())
 }

--- a/src-tauri/src/events/inbound/devices.rs
+++ b/src-tauri/src/events/inbound/devices.rs
@@ -27,9 +27,29 @@ pub async fn register_device(uuid: &str, mut event: PayloadEvent<crate::shared::
 		let mut locks = crate::store::profiles::acquire_locks_mut().await;
 		let selected_profile = locks.device_stores.get_selected_profile(&event.payload.id)?;
 		let profile = locks.profile_stores.get_profile_store(&DEVICES.get(&event.payload.id).unwrap(), &selected_profile)?;
+
+		// Lazy plugin activation on device connect: ensure plugins
+		// referenced by this device's active profile are spawned before
+		// firing will_appear events.
+		let mut needed_plugins = std::collections::HashSet::<String>::new();
+		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()) {
+			needed_plugins.insert(instance.action.plugin.clone());
+			if let Some(children) = &instance.children {
+				for child in children {
+					needed_plugins.insert(child.action.plugin.clone());
+				}
+			}
+		}
+		for uuid in &needed_plugins {
+			crate::plugins::ensure_plugin_spawned(uuid).await;
+		}
+
 		for instance in profile.value.keys.iter().flatten().chain(profile.value.sliders.iter().flatten()) {
 			let _ = crate::events::outbound::will_appear::will_appear(instance).await;
 		}
+
+		drop(locks);
+		crate::plugins::schedule_deactivation_sweep();
 
 		use tauri_plugin_aptabase::EventTracker;
 		let _ = crate::APP_HANDLE
@@ -69,6 +89,8 @@ pub async fn deregister_device(uuid: &str, event: PayloadEvent<String>) -> Resul
 		DEVICES.remove(&event.payload);
 		crate::device_sleep::deregister_device(&event.payload);
 		crate::events::frontend::update_devices().await;
+
+		crate::plugins::schedule_deactivation_sweep();
 
 		Ok(())
 	} else {

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -191,9 +191,14 @@ async fn run_deactivation_sweep() {
 		log::debug!("Deactivation sweep: no connected devices — skipping");
 		return;
 	}
+	// Device plugins serve devices (not per-profile actions) and must stay
+	// resident to detect hotplug and keep connected devices alive — never
+	// sweep them regardless of whether the current profile references any
+	// of their actions.
+	let device_plugin_uuids: std::collections::HashSet<String> = DEVICE_NAMESPACES.read().await.values().cloned().collect();
 	let to_remove: Vec<String> = {
 		let instances = INSTANCES.lock().await;
-		instances.keys().filter(|uuid| !needed.contains(uuid.as_str())).cloned().collect()
+		instances.keys().filter(|uuid| !needed.contains(uuid.as_str()) && !device_plugin_uuids.contains(uuid.as_str())).cloned().collect()
 	};
 	if to_remove.is_empty() {
 		log::debug!("Deactivation sweep: {} plugins needed, nothing to remove", needed.len());
@@ -669,9 +674,16 @@ pub fn initialise_plugins() {
 				let referenced = referenced.clone();
 				tokio::spawn(async move {
 					let uuid = path.file_name().and_then(|n| n.to_str()).map(String::from).unwrap_or_default();
-					let spawn_process = referenced.contains(&uuid);
+					// Device plugins declare a DeviceNamespace and serve a class of
+					// devices (not per-profile actions). They must stay resident to
+					// detect hotplug and keep connected devices alive, so lazy
+					// activation is scoped to action plugins only.
+					let is_device_plugin = manifest::read_manifest(&path).map(|m| m.device_namespace.is_some()).unwrap_or(false);
+					let spawn_process = is_device_plugin || referenced.contains(&uuid);
 					if !spawn_process {
 						log::info!("Registering {} metadata only (not referenced by any profile)", uuid);
+					} else if is_device_plugin && !referenced.contains(&uuid) {
+						log::info!("Spawning {} unconditionally (device plugin)", uuid);
 					}
 					if let Err(error) = initialise_plugin(&path, spawn_process).await {
 						warn!("Failed to initialise plugin at {}: {:#}", path.display(), error);

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -31,6 +31,184 @@ enum PluginInstance {
 pub static DEVICE_NAMESPACES: LazyLock<RwLock<HashMap<String, String>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
 static INSTANCES: LazyLock<Mutex<HashMap<String, PluginInstance>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// UUIDs currently in-flight through the spawn path — between the
+/// "we decided to spawn" point and the `INSTANCES.insert` at the end.
+/// Prevents duplicate subprocesses when the startup parallel-spawn loop
+/// races against a device register or profile switch that both reach for
+/// the same plugin. `std::sync::Mutex` so the claim can be released from
+/// `Drop` (no async await in Drop).
+static SPAWNING_UUIDS: LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> = LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+fn try_claim_spawn(uuid: &str) -> bool {
+	// HashSet::insert returns true iff the value was newly added — matches
+	// "succeeded if we claimed it first" in one lookup.
+	SPAWNING_UUIDS.lock().unwrap().insert(uuid.to_owned())
+}
+
+/// RAII guard: releases the SPAWNING_UUIDS claim on drop. Apply after a
+/// successful `try_claim_spawn` so every exit path from the spawn code
+/// (return, `?`, panic unwind) releases the claim.
+struct SpawnClaimGuard<'a>(&'a str);
+impl Drop for SpawnClaimGuard<'_> {
+	fn drop(&mut self) {
+		SPAWNING_UUIDS.lock().unwrap().remove(self.0);
+	}
+}
+
+/// Debounce window for the post-settle deactivation sweep. Rapid profile
+/// flipping or device connect/disconnect events cancel and restart the
+/// timer, so plugins only get deactivated once the user has genuinely
+/// settled on a configuration.
+const DEACTIVATION_SETTLE_SECS: u64 = 30;
+
+static DEACTIVATION_SWEEP: LazyLock<std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>> = LazyLock::new(|| std::sync::Mutex::new(None));
+
+/// Schedule a delayed deactivation sweep. Any pending sweep is cancelled
+/// and replaced — the new timer starts from zero. Call from profile
+/// switch, device connect, and device disconnect; the set of "needed"
+/// plugins only changes on those events. Synchronous so callers aren't
+/// pulled into the sweep's Send bounds.
+pub fn schedule_deactivation_sweep() {
+	let new_handle = tokio::spawn(async {
+		tokio::time::sleep(std::time::Duration::from_secs(DEACTIVATION_SETTLE_SECS)).await;
+		run_deactivation_sweep().await;
+	});
+	let mut guard = DEACTIVATION_SWEEP.lock().unwrap();
+	let old = guard.replace(new_handle);
+	drop(guard);
+	if let Some(h) = old {
+		h.abort();
+	}
+}
+
+/// Walk the profiles directory and return the set of plugin UUIDs
+/// referenced by any profile on disk. Used at startup by
+/// `initialise_plugins` to decide which plugins to spawn. Plugins not in
+/// this set have their metadata registered (so their actions appear in
+/// the profile editor UI) but their subprocess is never started, avoiding
+/// the memory pressure of idle plugins running forever. Startup-only —
+/// lazy spawn during normal operation is driven by the in-memory profile
+/// state via `ensure_plugin_spawned`.
+fn compute_referenced_plugin_uuids() -> std::collections::HashSet<String> {
+	use serde_json::Value;
+	fn collect(v: &Value, out: &mut std::collections::HashSet<String>) {
+		match v {
+			Value::Object(map) => {
+				if let Some(Value::String(s)) = map.get("plugin") {
+					out.insert(s.clone());
+				}
+				for (_, child) in map {
+					collect(child, out);
+				}
+			}
+			Value::Array(arr) => {
+				for item in arr {
+					collect(item, out);
+				}
+			}
+			_ => {}
+		}
+	}
+	fn walk(p: &path::Path, out: &mut std::collections::HashSet<String>) {
+		let Ok(entries) = fs::read_dir(p) else { return };
+		for entry in entries.flatten() {
+			let ep = entry.path();
+			if ep.is_dir() {
+				walk(&ep, out);
+			} else if ep.extension().and_then(|e| e.to_str()) == Some("json") {
+				let bytes = match fs::read(&ep) {
+					Ok(b) => b,
+					Err(error) => {
+						warn!("Skipping profile file {} (read failed): {}", ep.display(), error);
+						continue;
+					}
+				};
+				match serde_json::from_slice::<Value>(&bytes) {
+					Ok(v) => collect(&v, out),
+					Err(error) => {
+						warn!("Skipping profile file {} (malformed JSON): {}. Plugins referenced only by this profile will not be spawned at startup.", ep.display(), error);
+					}
+				}
+			}
+		}
+	}
+	let mut uuids = std::collections::HashSet::new();
+	walk(&config_dir().join("profiles"), &mut uuids);
+	uuids
+}
+
+/// Spawn a plugin's subprocess if it isn't already running. Idempotent;
+/// safe to call from the profile-switch path when a newly-selected
+/// profile references a plugin whose process wasn't started at boot.
+/// Also checks SPAWNING_UUIDS so a concurrent startup spawn of the same
+/// UUID isn't duplicated.
+pub async fn ensure_plugin_spawned(uuid: &str) {
+	if INSTANCES.lock().await.contains_key(uuid) {
+		return;
+	}
+	if SPAWNING_UUIDS.lock().unwrap().contains(uuid) {
+		return;
+	}
+	let path = config_dir().join("plugins").join(uuid);
+	if !path.exists() {
+		return;
+	}
+	if let Err(error) = initialise_plugin(&path, true).await {
+		warn!("Failed to lazily spawn plugin {}: {:#}", uuid, error);
+	}
+}
+
+/// Compute the set of plugin UUIDs referenced by the currently-selected
+/// profile of each connected device. Used by the deactivation sweep to
+/// decide what stays running. Copies out owned DeviceInfo values before
+/// any await so DashMap Refs don't span await points (they aren't Send).
+async fn compute_active_plugin_uuids() -> std::collections::HashSet<String> {
+	use crate::shared::DEVICES;
+	let mut needed = std::collections::HashSet::new();
+	let devices: Vec<(String, crate::shared::DeviceInfo)> = DEVICES.iter().map(|e| (e.key().clone(), e.value().clone())).collect();
+	if devices.is_empty() {
+		return needed;
+	}
+	let mut locks = crate::store::profiles::acquire_locks_mut().await;
+	for (device_id, device_info) in &devices {
+		let Ok(profile_id) = locks.device_stores.get_selected_profile(device_id) else { continue };
+		let Ok(store) = locks.profile_stores.get_profile_store(device_info, &profile_id) else { continue };
+		for instance in store.value.keys.iter().flatten().chain(store.value.sliders.iter().flatten()) {
+			needed.insert(instance.action.plugin.clone());
+			if let Some(children) = &instance.children {
+				for child in children {
+					needed.insert(child.action.plugin.clone());
+				}
+			}
+		}
+	}
+	needed
+}
+
+async fn run_deactivation_sweep() {
+	let needed = compute_active_plugin_uuids().await;
+	if needed.is_empty() {
+		log::debug!("Deactivation sweep: no connected devices — skipping");
+		return;
+	}
+	let to_remove: Vec<String> = {
+		let instances = INSTANCES.lock().await;
+		instances.keys().filter(|uuid| !needed.contains(uuid.as_str())).cloned().collect()
+	};
+	if to_remove.is_empty() {
+		log::debug!("Deactivation sweep: {} plugins needed, nothing to remove", needed.len());
+		return;
+	}
+	log::info!("Deactivation sweep: removing {} unused plugin(s), keeping {} needed", to_remove.len(), needed.len());
+	let Some(app) = APP_HANDLE.get() else { return };
+	for uuid in &to_remove {
+		log::info!("Deactivation sweep: stopping unused plugin {}", uuid);
+		if let Err(error) = deactivate_plugin(app, uuid).await {
+			warn!("Deactivation sweep failed to stop {}: {:#}", uuid, error);
+		}
+	}
+}
+
 pub static PORT_BASE: LazyLock<u16> = LazyLock::new(|| {
 	let mut base = 57116;
 	loop {
@@ -45,8 +223,19 @@ pub static PORT_BASE: LazyLock<u16> = LazyLock::new(|| {
 	base
 });
 
-/// Initialise a plugin from a given directory.
-pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
+/// Register a plugin's actions, categories, and device namespaces in
+/// OpenDeck's in-memory maps, and optionally spawn its subprocess.
+///
+/// When `spawn_process` is `false`, only the metadata is registered —
+/// the plugin's actions appear in the profile-editor UI but no
+/// subprocess is started. This is used at startup for plugins not
+/// referenced by any profile on disk, and matches the lazy-activation
+/// behavior of the real Elgato Stream Deck. When `spawn_process` is
+/// `true`, the full path runs: platform detection, code_path resolution,
+/// subprocess spawn, registration in `INSTANCES`. Call sites in user
+/// actions (install, reload) always pass `true`; the startup loop
+/// passes `true` only for referenced plugins.
+pub async fn initialise_plugin(path: &path::Path, spawn_process: bool) -> anyhow::Result<()> {
 	let plugin_uuid = path.file_name().unwrap().to_str().unwrap();
 
 	let mut manifest = manifest::read_manifest(path)?;
@@ -118,6 +307,32 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 	if let Some(namespace) = manifest.device_namespace {
 		DEVICE_NAMESPACES.write().await.insert(namespace, plugin_uuid.to_owned());
 	}
+
+	// Metadata-only path: the caller isn't asking us to spawn the plugin's
+	// subprocess (startup filter for unreferenced plugins). Actions are in
+	// CATEGORIES so the UI can still show them; the plugin will be spawned
+	// lazily by ensure_plugin_spawned when a profile that references it is
+	// activated.
+	if !spawn_process {
+		return Ok(());
+	}
+
+	// Race guard: if this plugin is already running OR another invocation
+	// is mid-spawn for the same UUID, bail out. Startup does N parallel
+	// tokio::spawn(initialise_plugin) — if a device register fires during
+	// that window, it would call ensure_plugin_spawned → initialise_plugin
+	// for an in-flight UUID and we'd end up with two subprocesses, one of
+	// which becomes orphaned when its Child handle is dropped (dropping
+	// Child does NOT kill the process on Unix). The atomic claim below
+	// prevents it.
+	if INSTANCES.lock().await.contains_key(plugin_uuid) {
+		return Ok(());
+	}
+	if !try_claim_spawn(plugin_uuid) {
+		log::debug!("Plugin {} spawn already in progress — skipping duplicate", plugin_uuid);
+		return Ok(());
+	}
+	let _claim = SpawnClaimGuard(plugin_uuid);
 
 	#[cfg(target_os = "windows")]
 	let platform = "windows";
@@ -328,7 +543,12 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 }
 
 pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow::Error> {
-	{
+	// Namespace + virtual-device cleanup. Errors here MUST NOT short-circuit
+	// the INSTANCES removal below — if a deregister_device failure propagated
+	// with `?`, the plugin's subprocess would stay running while its
+	// namespace is already gone, and subsequent sweeps couldn't find it
+	// cleanly. Log any error and continue to the process-kill path.
+	let namespace_cleanup: Result<(), anyhow::Error> = async {
 		let mut namespaces = DEVICE_NAMESPACES.write().await;
 		if let Some((namespace, _)) = namespaces.clone().iter().find(|(_, plugin)| uuid == **plugin) {
 			namespaces.remove(namespace);
@@ -339,6 +559,11 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 			}
 			crate::events::frontend::update_devices().await;
 		}
+		Ok(())
+	}
+	.await;
+	if let Err(error) = namespace_cleanup {
+		warn!("deactivate_plugin({}): namespace cleanup failed, continuing to kill subprocess: {:#}", uuid, error);
 	}
 
 	crate::application_watcher::stop_monitoring(uuid).await;
@@ -422,6 +647,16 @@ pub fn initialise_plugins() {
 		}
 	};
 
+	// Compute the set of plugins actually referenced by any profile on
+	// disk. Plugins NOT in this set have metadata registered but their
+	// process is not spawned — matches the lazy-activation behavior of
+	// the real Elgato Stream Deck and stops OpenDeck from eagerly
+	// launching every installed plugin regardless of whether it's used.
+	// Plugins required by a profile activated later (profile switch or
+	// new device connect) are spawned lazily via ensure_plugin_spawned.
+	let referenced = std::sync::Arc::new(compute_referenced_plugin_uuids());
+	log::info!("Startup: {} plugins referenced by profiles on disk", referenced.len());
+
 	// Iterate through all directory entries in the plugins folder and initialise them as plugins if appropriate
 	for entry in entries {
 		if let Ok(entry) = entry {
@@ -431,8 +666,14 @@ pub fn initialise_plugins() {
 			};
 			let metadata = fs::metadata(&path).unwrap();
 			if metadata.is_dir() {
+				let referenced = referenced.clone();
 				tokio::spawn(async move {
-					if let Err(error) = initialise_plugin(&path).await {
+					let uuid = path.file_name().and_then(|n| n.to_str()).map(String::from).unwrap_or_default();
+					let spawn_process = referenced.contains(&uuid);
+					if !spawn_process {
+						log::info!("Registering {} metadata only (not referenced by any profile)", uuid);
+					}
+					if let Err(error) = initialise_plugin(&path, spawn_process).await {
 						warn!("Failed to initialise plugin at {}: {:#}", path.display(), error);
 					}
 				});


### PR DESCRIPTION
## Problem

OpenDeck currently spawns every installed plugin at startup regardless of whether any profile references it. This creates three compounding issues:

1. **Idle-plugin memory pressure.** Plugins the user doesn't have any action for still run continuously. Polling loops, WebSocket clients, per-plugin heaps — all active.
2. **The problem gets much worse with #317.** Touch-strip swipe to switch profiles makes profile switches cheap and frequent. Without lazy activation, every profile's plugins stay resident simultaneously. Users who swipe through 5 profiles have every plugin from all 5 running, even though only one profile is on screen.
3. **Divergence from Elgato's real Stream Deck.** Elgato's host launches plugins on demand based on the actions the user has configured, not eagerly.

## Change

- **Startup:** register every installed plugin's metadata (`CATEGORIES`, `DEVICE_NAMESPACES`) so the profile editor shows available actions for all installed plugins, but only spawn subprocesses for plugins referenced by at least one profile on disk.
- **Profile switch / device connect:** lazily spawn plugins the new profile references that aren't already running (`ensure_plugin_spawned`).
- **Deactivation on settle:** 30-second debounce after any profile/device event. Once settled, deactivate any plugin not referenced by the selected profile on any connected device. Rapid profile flipping cancels and restarts the timer — no plugin thrashing during fast swipes.

Matches the lazy-activation behavior of Elgato's real Stream Deck.

## Why not keep plugins warm

Rejected as the wrong default. If a plugin isn't referenced by the current profile on any connected device, the user isn't using it. Keeping it resident for some arbitrary N-last-used window trades clarity for an optimization that doesn't matter — plugin startup is fast enough that users won't notice. Every plugin is already restart-safe by construction (OpenDeck kills and respawns every plugin on every OpenDeck restart; a plugin that can't survive that is dead on day 1).

## Atomicity fix bundled

`deactivate_plugin` previously used `?` to short-circuit out of namespace cleanup. If `deregister_device` returned `Err`, the plugin's subprocess would stay running while its namespace was already removed from `DEVICE_NAMESPACES`. Subsequent sweeps couldn't find it cleanly. This PR wraps the namespace cleanup in an inner async block, logs any error via `warn!`, and always proceeds to the subprocess-kill path.

## Concurrent-spawn race guard

`initialise_plugins` fires parallel `tokio::spawn(initialise_plugin)` per plugin directory. If a device registers during that window, `ensure_plugin_spawned` for a UUID that's already in-flight would start a **second** subprocess; the second's `INSTANCES.insert` overwrites the first, and the first's `Child` handle is dropped — which on Unix does NOT kill the process. Result: a self-inflicted orphan.

This PR adds `SPAWNING_UUIDS: std::sync::Mutex<HashSet<String>>` with `try_claim_spawn` (atomic check-and-insert via `HashSet::insert` return value) and a `SpawnClaimGuard` RAII wrapper that releases the claim on any exit from the spawn path (return, `?`, panic unwind).

## Platform behavior

Behavior identical on all platforms. No OS-specific code.

## Testing

1. **Startup filter:** with 11 installed plugins, 3 referenced by the active profile. On current `main`: 11 subprocesses. With this PR: 3 subprocesses, 8 log lines reading `Registering X metadata only (not referenced by any profile)`. Profile editor UI still shows all 11 plugins' actions.
2. **Profile switch lazy spawn:** switch to a profile that references an unstarted plugin. That plugin's subprocess appears within the `will_appear` event firing.
3. **Deactivation on settle:** switch to a profile that doesn't reference a currently-running plugin. 30 seconds later, log shows `Deactivation sweep: removing N unused plugin(s)` and `pgrep -af -- '-pluginUUID'` drops.
4. **Rapid profile flipping:** switch A → B → A within 5 seconds. No deactivation fires (timer cancelled and restarted each time). Plugin count stable.
5. **Concurrent spawn race:** Hard to trigger naturally; covered by structural fix + RAII guard.
6. **Atomicity:** forced a `deregister_device` error via a contrived device namespace; the plugin subprocess was still killed, namespace error logged.

## Reviewer context

This is a behavioral change to plugin lifecycle. Happy to split further if you'd prefer the concurrent-spawn race fix and atomicity fix as their own PR — they're defensive hardening that landed in the same commit because the lazy-spawn path exposed them. Let me know.