### PR TITLE
fix: resolve race condition causing ENOENT error caused by concurrent accesses to the Settings store

### DIFF
--- a/src-tauri/src/device_sleep.rs
+++ b/src-tauri/src/device_sleep.rs
@@ -9,9 +9,7 @@ static LAST_ACTIVITY: LazyLock<DashMap<String, Instant>> = LazyLock::new(DashMap
 static SLEEPING_DEVICES: LazyLock<DashMap<String, ()>> = LazyLock::new(DashMap::new);
 
 pub fn init_device_sleep() {
-	if let Ok(settings) = crate::store::get_settings() {
-		SLEEP_TIMEOUT_MINUTES.store(settings.value.sleep_timeout_minutes, Ordering::Relaxed);
-	}
+	SLEEP_TIMEOUT_MINUTES.store(crate::store::get_settings().value.sleep_timeout_minutes, Ordering::Relaxed);
 
 	tokio::spawn(async {
 		loop {
@@ -70,7 +68,7 @@ async fn sleep_idle_devices() -> Result<(), anyhow::Error> {
 
 async fn wake_device(device: &str) -> Result<bool, anyhow::Error> {
 	if SLEEPING_DEVICES.remove(device).is_some() {
-		let brightness = crate::store::get_settings().map(|s| s.value.brightness).unwrap_or(50);
+		let brightness = crate::store::get_settings().value.brightness;
 		crate::events::outbound::devices::set_device_brightness(device, brightness).await?;
 		return Ok(true);
 	}

--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -116,9 +116,7 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 	};
 	let _ = device.clear_all_button_images().await;
 	clear_all_touchpoints(&device).await;
-	if let Ok(settings) = crate::store::get_settings() {
-		let _ = device.set_brightness(settings.value.brightness).await;
-	}
+	let _ = device.set_brightness(crate::store::get_settings().value.brightness).await;
 	let _ = device.flush().await;
 	crate::events::inbound::devices::register_device(
 		"",
@@ -180,16 +178,14 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 
 /// Attempt to initialise all connected devices.
 pub async fn initialise_devices() {
-	if let Ok(settings) = crate::store::get_settings() {
-		if settings.value.disableelgato {
-			crate::plugins::DEVICE_NAMESPACES
-				.write()
-				.await
-				.insert("sd".to_owned(), "opendeck_alternative_elgato_implementation".to_owned());
-			return;
-		} else {
-			crate::plugins::DEVICE_NAMESPACES.write().await.remove("sd");
-		}
+	if crate::store::get_settings().value.disableelgato {
+		crate::plugins::DEVICE_NAMESPACES
+			.write()
+			.await
+			.insert("sd".to_owned(), "opendeck_alternative_elgato_implementation".to_owned());
+		return;
+	} else {
+		crate::plugins::DEVICE_NAMESPACES.write().await.remove("sd");
 	}
 
 	// Iterate through detected Elgato devices and attempt to register them.

--- a/src-tauri/src/events/frontend/settings.rs
+++ b/src-tauri/src/events/frontend/settings.rs
@@ -15,12 +15,8 @@ use tauri_plugin_dialog::{DialogExt, FilePath};
 use zip::{ZipWriter, write::FileOptions};
 
 #[command]
-pub async fn get_settings() -> Result<crate::store::Settings, Error> {
-	let store = crate::store::get_settings();
-	match store {
-		Ok(store) => Ok(store.value),
-		Err(error) => Err(error.into()),
-	}
+pub async fn get_settings() -> crate::store::Settings {
+	crate::store::get_settings().value
 }
 
 #[command]
@@ -33,11 +29,8 @@ pub async fn set_settings(_app: AppHandle, settings: crate::store::Settings) -> 
 
 	crate::events::outbound::devices::set_brightness(settings.brightness).await?;
 	crate::device_sleep::update_timeout_minutes(settings.sleep_timeout_minutes);
-	let mut store = match crate::store::get_settings() {
-		Ok(store) => store,
-		Err(error) => return Err(error.into()),
-	};
 
+	let mut store = crate::store::SETTINGS_MUT.lock().await;
 	store.value = settings;
 	store.save()?;
 	Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -119,7 +119,7 @@ async fn main() {
 				let _ = std::fs::rename(old, app.path().app_config_dir().unwrap());
 			}
 
-			let mut settings = store::get_settings()?;
+			let mut settings = store::get_settings();
 			use std::cmp::Ordering;
 			use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 			let current_version = semver::Version::parse(built_info::PKG_VERSION)?;
@@ -359,7 +359,7 @@ If you have already donated, thank you so much for your support!"#,
 				return;
 			}
 			if let WindowEvent::CloseRequested { api, .. } = event {
-				if let Ok(true) = store::get_settings().map(|store| store.value.background) {
+				if store::get_settings().value.background {
 					let _ = hide_window(window.app_handle());
 					api.prevent_close();
 				} else {

--- a/src-tauri/src/plugins/info_param.rs
+++ b/src-tauri/src/plugins/info_param.rs
@@ -79,7 +79,7 @@ pub async fn make_info(uuid: String, version: String, wine: bool) -> Info {
 	Info {
 		application: ApplicationInfo {
 			font: "ui-sans-serif".to_owned(),
-			language: crate::store::get_settings().unwrap().value.language,
+			language: crate::store::get_settings().value.language,
 			platform: if !wine { platform.to_owned() } else { "windows".to_owned() },
 			platformVersion: if !wine { os_info::get().version().to_string() } else { "10.0.19045.4474".to_owned() },
 			version: "7.1.0".to_owned(),

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -5,7 +5,6 @@ mod webserver;
 use crate::APP_HANDLE;
 use crate::built_info::TARGET;
 use crate::shared::{CATEGORIES, Category, config_dir, convert_icon, is_flatpak, log_dir};
-use crate::store::get_settings;
 
 use std::collections::HashMap;
 use std::process::{Child, Command, Stdio};
@@ -289,7 +288,7 @@ pub async fn initialise_plugin(path: &path::Path) -> anyhow::Result<()> {
 			.arg(serde_json::to_string(&info)?)
 			.stdout(Stdio::from(log_file.try_clone()?))
 			.stderr(Stdio::from(log_file));
-		if get_settings()?.value.separatewine {
+		if crate::store::get_settings().value.separatewine {
 			command.env("WINEPREFIX", path.join("wineprefix").to_string_lossy().to_string());
 		} else {
 			let _ = fs::remove_dir_all(path.join("wineprefix"));

--- a/src-tauri/src/plugins/webserver.rs
+++ b/src-tauri/src/plugins/webserver.rs
@@ -46,10 +46,7 @@ pub async fn init_webserver(prefix: PathBuf) {
 		}
 
 		// Ensure the requested path is within the config directory to prevent unrestricted access to the filesystem.
-		let developer = match crate::store::Store::new("settings", &prefix, crate::store::Settings::default()) {
-			Ok(store) => store.value.developer,
-			Err(_) => false,
-		};
+		let developer = crate::store::get_settings().value.developer;
 		if !developer && !path.canonicalize().is_ok_and(|p| p.starts_with(&prefix)) {
 			let _ = request.respond(Response::empty(403));
 			continue;

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -90,6 +90,7 @@ where
 		}
 	}
 
+	/// Save the relevant Store as a file
 	pub fn save(&self) -> Result<(), anyhow::Error> {
 		fs::create_dir_all(self.path.parent().unwrap())?;
 

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -73,7 +73,23 @@ where
 		}
 	}
 
-	/// Save the relevant Store as a file
+	/// Create a new Store given an ID and storage directory, without removing the temporary and backup files that may be in use by another instance of Store
+	pub fn new_concurrent(id: &str, config_dir: &Path, default: T) -> Self {
+		let path = config_dir.join(format!("{}.json", id));
+		let temp_path = path.with_extension("json.temp");
+		let backup_path = path.with_extension("json.bak");
+
+		if let Ok(value) = Self::validate_file_contents(&path) {
+			Self { path, value }
+		} else if let Ok(value) = Self::validate_file_contents(&temp_path) {
+			Self { path, value }
+		} else if let Ok(value) = Self::validate_file_contents(&backup_path) {
+			Self { path, value }
+		} else {
+			Self { path, value: default }
+		}
+	}
+
 	pub fn save(&self) -> Result<(), anyhow::Error> {
 		fs::create_dir_all(self.path.parent().unwrap())?;
 
@@ -146,6 +162,9 @@ impl Default for Settings {
 
 impl NotProfile for Settings {}
 
-pub fn get_settings() -> Result<Store<Settings>, anyhow::Error> {
-	Store::new("settings", &crate::shared::config_dir(), Settings::default())
+pub fn get_settings() -> Store<Settings> {
+	Store::new_concurrent("settings", &crate::shared::config_dir(), Settings::default())
 }
+
+pub static SETTINGS_MUT: std::sync::LazyLock<tokio::sync::Mutex<Store<Settings>>> =
+	std::sync::LazyLock::new(|| tokio::sync::Mutex::new(Store::new_concurrent("settings", &crate::shared::config_dir(), Settings::default())));


### PR DESCRIPTION
<details>

<summary>Preflight checklist</summary>

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

</details>

---

`Store::new()` cleans up the temp and backup files used to atomically save store content, which is not an issue for profile and device stores as they are only ever instantiated once, and never concurrently accessed (due to being accessed through RwLocks).

However, as the settings store (i.e. the store used for app settings) is accessed by multiple parts of the application without synchronisation and is instantiated multiple times, when the temp and backup files were cleaned up by creating a new instance, this could interrupt a save operation in progress by another instance.

This PR introduces a new method, `Store::new_concurrent()`, which skips the cleanup of the temp and backup files, so that Store can be instantiated multiple times without interfering with each other (the save operation is already managed by file locks).

Therefore, the `No such file or directory (os error 2)` error incurred when saving the application settings is resolved, as the temporary file is now never removed in the middle of a save operation.

Hopefully that makes sense!