### PR TITLE
fix(macos): stop sleep/wake crash by pinning hidapi to a dedicated thread

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1306,8 +1306,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elgato-streamdeck"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e86db7c0f5bbffc406f4226ea5bf900bfd818bd8e4f93482bdc1ceeb17824ac"
+source = "git+https://github.com/kingb/rust-elgato-streamdeck?branch=feat%2Fasync-from-sync-0.12#cb2c983054370b8223cb7bdeb53eb721d0e95b2a"
 dependencies = [
  "hidapi",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,3 +61,11 @@ windows-sys = "0.61"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]
+
+# elgato-streamdeck with an added `From<StreamDeck> for AsyncStreamDeck`, so
+# device enumeration/open can be pinned to a dedicated HID thread (see
+# elgato.rs). Fixes a macOS sleep/wake crash where hidapi's IOHIDManager was
+# driven from a foreign thread's run loop. Drop this patch once the upstream PR
+# lands in a release: https://github.com/OpenActionAPI/rust-elgato-streamdeck/pull/59
+[patch.crates-io]
+elgato-streamdeck = { git = "https://github.com/kingb/rust-elgato-streamdeck", branch = "feat/async-from-sync-0.12" }

--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -1,20 +1,87 @@
 use crate::events::inbound;
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use base64::Engine as _;
 use elgato_streamdeck::{
-	AsyncStreamDeck, DeviceStateUpdate,
+	AsyncStreamDeck, DeviceStateUpdate, StreamDeck,
 	images::{ImageRect, convert_image_with_format_async},
 	info::Kind,
 };
 use image::GenericImageView as _;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, mpsc, oneshot};
 
 static ELGATO_DEVICES: LazyLock<RwLock<HashMap<String, AsyncStreamDeck>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
-static HIDAPI: LazyLock<RwLock<Option<Arc<hidapi::HidApi>>>> = LazyLock::new(|| RwLock::new(None));
+
+/// A request to the dedicated HID thread: enumerate connected Stream Decks and
+/// open any whose device ID isn't already in `known`, replying with the opened
+/// (device_id, StreamDeck) pairs.
+struct HidScan {
+	known: HashSet<String>,
+	reply: oneshot::Sender<Vec<(String, StreamDeck)>>,
+}
+
+/// Sender to the dedicated HID thread (see [hid_thread_main]).
+///
+/// On macOS, hidapi's `IOHIDManager` is implicitly bound to the run loop of the
+/// thread that created the `HidApi`, and enumerating/opening devices from any
+/// other thread schedules IOKit sources on a foreign run loop — which traps in
+/// CoreFoundation (a PAC / `EXC_BREAKPOINT` crash), most reliably right after a
+/// sleep/wake when the device set changes. The previous code shared one
+/// `HidApi` across arbitrary tokio worker threads (elgato-streamdeck's
+/// `block_in_place` does NOT pin to a single thread), so it was exposed to this.
+///
+/// We instead create the `HidApi` once on a single dedicated OS thread and run
+/// every enumerate/open on that same thread via the synchronous API (which,
+/// unlike the async wrappers, never calls `block_in_place`). Opened devices are
+/// `Send`, so they're handed back and wrapped for async use afterwards.
+static HID_TX: LazyLock<mpsc::UnboundedSender<HidScan>> = LazyLock::new(|| {
+	let (tx, rx) = mpsc::unbounded_channel::<HidScan>();
+	std::thread::Builder::new()
+		.name("opendeck-hid".to_owned())
+		.spawn(move || hid_thread_main(rx))
+		.expect("failed to spawn HID thread");
+	tx
+});
+
+/// Body of the dedicated HID thread. Owns the `HidApi` for its entire lifetime
+/// and services scan requests one at a time on this thread.
+fn hid_thread_main(mut rx: mpsc::UnboundedReceiver<HidScan>) {
+	let mut hid: Option<hidapi::HidApi> = None;
+	while let Some(scan) = rx.blocking_recv() {
+		let api = match hid {
+			Some(ref mut api) => {
+				if let Err(error) = elgato_streamdeck::refresh_device_list(api) {
+					log::warn!("Failed to refresh HID device list: {error}");
+				}
+				api
+			}
+			None => match elgato_streamdeck::new_hidapi() {
+				Ok(api) => hid.insert(api),
+				Err(error) => {
+					log::warn!("Failed to initialise hidapi: {error}");
+					let _ = scan.reply.send(Vec::new());
+					continue;
+				}
+			},
+		};
+
+		let mut opened = Vec::new();
+		for (kind, serial) in elgato_streamdeck::list_devices(api) {
+			let device_id = format!("sd-{serial}");
+			if scan.known.contains(&device_id) {
+				continue;
+			}
+			match StreamDeck::connect(api, kind, &serial) {
+				Ok(device) => opened.push((device_id, device)),
+				Err(error) => log::warn!("Failed to connect to Elgato device: {error}"),
+			}
+		}
+		let _ = scan.reply.send(opened);
+	}
+}
 
 /// Extract the average colour from an image.
 fn extract_average_colour(img: &image::DynamicImage) -> (u8, u8, u8) {
@@ -188,32 +255,23 @@ pub async fn initialise_devices() {
 		crate::plugins::DEVICE_NAMESPACES.write().await.remove("sd");
 	}
 
-	// Iterate through detected Elgato devices and attempt to register them.
-	let current = HIDAPI.read().await.as_ref().cloned();
-	let hid = match current {
-		Some(arc) => arc,
-		None => match elgato_streamdeck::new_hidapi() {
-			Ok(hid) => {
-				let arc = Arc::new(hid);
-				HIDAPI.write().await.replace(arc.clone());
-				arc
-			}
-			Err(error) => {
-				log::warn!("Failed to initialise hidapi: {error}");
-				return;
-			}
-		},
+	// Enumerate and open devices on the dedicated HID thread (see HID_TX) so
+	// hidapi's IOHIDManager is only ever driven from its owning thread.
+	let known: HashSet<String> = ELGATO_DEVICES.read().await.keys().cloned().collect();
+	let (reply, rx) = oneshot::channel();
+	if HID_TX.send(HidScan { known, reply }).is_err() {
+		log::warn!("HID thread is gone; cannot enumerate devices");
+		return;
+	}
+	let opened = match rx.await {
+		Ok(opened) => opened,
+		Err(_) => {
+			log::warn!("HID thread dropped the scan request");
+			return;
+		}
 	};
-	for (kind, serial) in elgato_streamdeck::asynchronous::list_devices_async(&hid) {
-		let device_id = format!("sd-{serial}");
-		if ELGATO_DEVICES.read().await.contains_key(&device_id) {
-			continue;
-		}
-		match elgato_streamdeck::AsyncStreamDeck::connect(&hid, kind, &serial) {
-			Ok(device) => {
-				tokio::spawn(init(device, device_id));
-			}
-			Err(error) => log::warn!("Failed to connect to Elgato device: {error}"),
-		}
+	for (device_id, device) in opened {
+		// The device may have been registered since the scan; init() re-checks.
+		tokio::spawn(init(AsyncStreamDeck::from(device), device_id));
 	}
 }


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [] I will keep "Allow edits from maintainers" enabled for this pull request.

---

## Summary

On macOS, OpenDeck reliably crashes a few seconds after the machine wakes from
sleep, with an `EXC_BREAKPOINT` inside CoreFoundation:

```
__CFCheckCFInfoPACSignature
  ← CFRunLoopAddSource
  ← IOHIDDeviceScheduleWithRunLoop
  ← hidapi hid_open / hid_enumerate
  ← elgato_streamdeck::AsyncStreamDeck::connect
```

### Root cause

hidapi's macOS backend binds its `IOHIDManager` to the run loop of the thread
that created the `HidApi`. Enumerating or opening a device from any *other*
thread schedules IOKit sources on a foreign run loop, which trips a
CoreFoundation pointer-authentication check and traps. This is most reliably
hit right after a sleep/wake, when the periodic device poll runs while the
device set is changing.

The current code stores a single `HidApi` in a `LazyLock<RwLock<Option<Arc<…>>>>`
and calls the async enumerate/connect wrappers from whatever tokio worker thread
happens to run `initialise_devices()`. elgato-streamdeck's async wrappers use
`block_in_place`, which does **not** pin work to one OS thread (confirmed even on
a single-worker runtime), so the `IOHIDManager` ends up driven from a foreign
thread.

### Fix

Create the `HidApi` once on a dedicated, long-lived OS thread (`opendeck-hid`)
and run *every* enumerate/open on that same thread via the **synchronous**
elgato-streamdeck API (which never calls `block_in_place`). Opened `StreamDeck`
handles are `Send`, so they're handed back over a channel and wrapped with
`AsyncStreamDeck::from(device)` for async use as before. `initialise_devices()`
now sends a scan request to that thread and awaits the opened devices.

No behavior change to device handling otherwise — same `sd-<serial>` IDs, same
`init()` path, same dedup against already-registered devices.

## Dependency note (why this needs an elgato-streamdeck release)

The fix wraps an already-opened sync `StreamDeck` for async use, which needs
`impl From<StreamDeck> for AsyncStreamDeck`. That was added upstream in
OpenActionAPI/rust-elgato-streamdeck#59 (merged), but is **not yet in a
published crates.io release** — the latest release predates the merge.

To keep this buildable today, `Cargo.toml` temporarily points
`elgato-streamdeck` at a fork branch carrying that commit on top of the 0.12.1
release (the version OpenDeck currently pins):

```toml
[patch.crates-io]
elgato-streamdeck = { git = "https://github.com/kingb/rust-elgato-streamdeck", branch = "feat/async-from-sync-0.12" }
```

**This `[patch.crates-io]` is a placeholder and should not merge as-is.** Once a
release of elgato-streamdeck containing #59 is published, the patch should be
dropped and the dependency bumped to that version. Opening this now to surface
the macOS fix and to motivate cutting that release. Happy to update the PR to a
plain version bump the moment a release is available.

(If the release lands as 0.13.x rather than a 0.12.x point release, the bump
will also need a one-line `Kind::PlusXl` arm added to the `device_type` match in
`elgato.rs`, since 0.13 introduced that device variant and the match is
exhaustive. Not included here because OpenDeck still pins 0.12.)

## Testing

- Reproduced the original crash: stock build, sleep the Mac, wake it, crash
  within ~10s. Symbolicated the report to the trace above.
- With the fix: confirmed the `opendeck-hid` thread is present, device
  enumeration/open run on it, and the app survives repeated sleep/wake cycles
  with the Stream Deck attached and re-enumerating.
- Normal hotplug (unplug/replug while running) still registers devices.
