### PR TITLE
feat: add system sleep/wake recovery for devices and webview plugins

### DIFF
--- a/src-tauri/src/events/outbound/misc.rs
+++ b/src-tauri/src/events/outbound/misc.rs
@@ -1,0 +1,15 @@
+use super::send_to_all_plugins;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct SystemDidWakeUpEvent {
+	event: &'static str,
+}
+
+pub async fn system_did_wake_up() -> Result<(), anyhow::Error> {
+	send_to_all_plugins(&SystemDidWakeUpEvent {
+		event: "systemDidWakeUp",
+	})
+	.await
+}

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -3,6 +3,7 @@ pub mod deep_link;
 pub mod devices;
 pub mod encoder;
 pub mod keypad;
+pub mod misc;
 pub mod property_inspector;
 pub mod settings;
 pub mod states;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod events;
 mod plugins;
 mod shared;
 mod store;
+mod system_sleep_watchdog;
 mod zip_extract;
 
 mod built_info {
@@ -197,6 +198,7 @@ If you have already donated, thank you so much for your support!"#,
 			plugins::initialise_plugins();
 			application_watcher::init_application_watcher();
 			device_sleep::init_device_sleep();
+			system_sleep_watchdog::init_watchdog();
 
 			let label = IconMenuItemBuilder::with_id("label", PRODUCT_NAME)
 				.icon(app.default_window_icon().unwrap().clone())

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -391,6 +391,146 @@ pub async fn deactivate_plugins() {
 	}
 }
 
+/// Reconnect all webview plugins after system wake.
+///
+/// Webview plugins lose both their WebSocket connection AND their Web Worker
+/// timers when the system enters sleep.  The Elgato SDK uses a Web Worker
+/// (`timers.js`) that overrides `setTimeout`/`setInterval`; this Worker dies
+/// during sleep and does not resume, so even if the WebSocket were reconnected
+/// the plugin's timers (e.g. clock animations) would remain frozen.
+///
+/// The fix is a two-step process:
+///   1. Reload the webview page (`location.reload()`) — this gives the plugin
+///      a fresh JavaScript environment with a new Web Worker and fresh timer
+///      overrides.
+///   2. Restore native browser timers via a hidden iframe and re-evaluate the
+///      connection init JavaScript — this creates a new WebSocket to the
+///      OpenDeck server and sends `registerPlugin`.
+///
+/// We avoid closing and recreating the Tauri window because `window.close()`
+/// does not reliably destroy webviews on Windows.
+pub async fn reload_webview_plugins() {
+	let app = match APP_HANDLE.get() {
+		Some(app) => app,
+		None => return,
+	};
+
+	// Collect webview plugin UUIDs (don't hold lock across await points).
+	let webview_uuids: Vec<String> = {
+		let instances = INSTANCES.lock().await;
+		instances
+			.iter()
+			.filter(|(_, instance)| matches!(instance, PluginInstance::Webview))
+			.map(|(uuid, _)| uuid.clone())
+			.collect()
+	};
+
+	if webview_uuids.is_empty() {
+		return;
+	}
+
+	log::info!("Reconnecting {} webview plugin(s) after system wake", webview_uuids.len());
+
+	for uuid in webview_uuids {
+		log::info!("Reconnecting webview plugin: {}", uuid);
+
+		let window = match app.get_webview_window(&uuid.replace('.', "_")) {
+			Some(w) => w,
+			None => {
+				warn!("Webview window not found for plugin {}", uuid);
+				continue;
+			}
+		};
+
+		// Step 1: Reload the page.  This destroys the old (dead) Web Worker
+		// and loads all scripts fresh, including timers.js which creates a
+		// new Worker with working setTimeout/setInterval.
+		if let Err(e) = window.eval("location.reload()") {
+			error!("Failed to reload page for {}: {}", uuid, e);
+			continue;
+		}
+		log::info!("Page reload triggered for {}", uuid);
+
+		// Give the page time to start loading.  Scripts are loaded from the
+		// local webserver (localhost) so this is fast.  The init JS below
+		// also has its own retry mechanism for when the page isn't ready yet.
+		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+		// Read the manifest to get the plugin version for the info parameter.
+		let plugin_dir = config_dir().join("plugins").join(&uuid);
+		let manifest = match manifest::read_manifest(&plugin_dir) {
+			Ok(m) => m,
+			Err(e) => {
+				warn!("Failed to read manifest for {}: {:#}", uuid, e);
+				continue;
+			}
+		};
+
+		let info = info_param::make_info(uuid.clone(), manifest.version, false).await;
+		let info_json = match serde_json::to_string(&info) {
+			Ok(j) => j,
+			Err(e) => {
+				warn!("Failed to serialise info for {}: {}", uuid, e);
+				continue;
+			}
+		};
+
+		// Step 2: Re-evaluate the connection init JavaScript.
+		//
+		// Before reconnecting, we restore native browser timers via a hidden
+		// iframe.  The Elgato SDK's `timers.js` overrides `window.setInterval`
+		// and `window.setTimeout` with Web Worker-based replacements.  After
+		// system sleep the Worker dies and all timers stop.  Even after a page
+		// reload the new Worker may be unreliable, so we bypass it entirely by
+		// restoring the native timer functions.
+		//
+		// The `opendeckReconnect` function then checks `document.readyState`
+		// and retries until the page is loaded, then calls the SDK's socket
+		// connection function which creates a fresh WebSocket.
+		let init_js = format!(
+			r#"(() => {{
+				// Restore native timers — the Worker-based ones may be dead.
+				try {{
+					const f = document.createElement('iframe');
+					f.style.display = 'none';
+					document.body.appendChild(f);
+					const w = f.contentWindow;
+					window.setInterval = w.setInterval.bind(w);
+					window.clearInterval = w.clearInterval.bind(w);
+					window.setTimeout = w.setTimeout.bind(w);
+					window.clearTimeout = w.clearTimeout.bind(w);
+					console.log('[opendeck] Native timers restored');
+				}} catch(e) {{
+					console.warn('[opendeck] Could not restore native timers:', e);
+				}}
+
+				const opendeckReconnect = () => {{
+					try {{
+						if (document.readyState !== "complete") throw new Error("not ready");
+						if (typeof connectOpenActionSocket === "function") connectOpenActionSocket({port}, "{uuid}", "{event}", `{info}`);
+						else connectElgatoStreamDeckSocket({port}, "{uuid}", "{event}", `{info}`);
+						console.log('[opendeck] WebSocket reconnect initiated');
+					}} catch (e) {{
+						setTimeout(opendeckReconnect, 50);
+					}}
+				}};
+				opendeckReconnect();
+			}})();
+			"#,
+			port = *PORT_BASE,
+			uuid = uuid,
+			event = "registerPlugin",
+			info = info_json
+		);
+
+		if let Err(e) = window.eval(&init_js) {
+			error!("Failed to eval reconnect JS for {}: {}", uuid, e);
+		} else {
+			log::info!("Reconnect JS evaluated for {}", uuid);
+		}
+	}
+}
+
 /// Initialise plugins from the plugins directory.
 pub fn initialise_plugins() {
 	tokio::spawn(init_websocket_server());

--- a/src-tauri/src/system_sleep_watchdog.rs
+++ b/src-tauri/src/system_sleep_watchdog.rs
@@ -1,0 +1,73 @@
+use std::time::{Duration, SystemTime};
+
+/// Initialise the system sleep/wake watchdog.
+///
+/// This spawns a background task that monitors system wall-clock time to detect
+/// when the system has been in sleep or hibernation. Upon detecting a wake event,
+/// it waits for the USB subsystem to stabilise, then reinitialises connected
+/// devices and wakes any that were put to sleep before the system slept.
+pub fn init_watchdog() {
+	tokio::spawn(async {
+		// Poll at 1 Hz — cheap and gives us sub-second responsiveness on wake.
+		let poll_interval = Duration::from_secs(1);
+		// Anything above 3 s of wall-clock time between consecutive polls means
+		// the system was almost certainly in sleep/hibernation.  This is well
+		// above the 1 s poll interval even with moderate scheduler noise.
+		let sleep_threshold = Duration::from_secs(3);
+		// Give the USB subsystem time to re-enumerate devices after resume.
+		let stabilization_delay = Duration::from_secs(2);
+
+		let mut last_check = SystemTime::now();
+
+		loop {
+			tokio::time::sleep(poll_interval).await;
+
+			let now = SystemTime::now();
+			// `unwrap_or(Duration::ZERO)` gracefully handles system clock
+			// adjustments (e.g. NTP) that cause `now` to precede `last_check`.
+			let elapsed = now.duration_since(last_check).unwrap_or(Duration::ZERO);
+
+			if elapsed > sleep_threshold {
+				log::info!(
+					"System sleep/wake detected (elapsed: {:?}), reinitialising devices",
+					elapsed,
+				);
+
+				// Wait for USB to stabilise after resume so that devices are
+				// properly re-enumerated before we try to connect to them.
+				tokio::time::sleep(stabilization_delay).await;
+
+				// Re-enumerate Elgato / Stream Deck devices.  This is
+				// idempotent — already-registered devices are skipped.
+				crate::elgato::initialise_devices().await;
+
+				// Wake any devices that were put to sleep before the system
+				// slept (idle-timeout via device_sleep).
+				for device in crate::shared::DEVICES.iter() {
+					let _ = crate::device_sleep::note_activity(&device.id).await;
+				}
+
+				// Notify all plugins that the system has woken up, so they
+				// can reinitialise their own devices if needed.
+				let _ = crate::events::outbound::misc::system_did_wake_up().await;
+
+				// Reload webview plugins whose WebSocket connections died
+				// during sleep.  The Elgato/openaction SDK has no built-in
+				// reconnection, so we close and recreate the webview window.
+				// A short delay lets the WebSocket server and other subsystems
+				// finish settling before we reconnect.
+				tokio::spawn(async {
+					tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+					crate::plugins::reload_webview_plugins().await;
+				});
+
+				// Reset last_check after handling to prevent the next poll
+				// from re-triggering wake detection due to time spent in
+				// the stabilization delay and device reinitialisation.
+				last_check = SystemTime::now();
+			} else {
+				last_check = now;
+			}
+		}
+	});
+}


### PR DESCRIPTION
## Summary

On Windows, system sleep/hibernation causes three categories of failure that leave
Stream Deck devices and plugins non-functional after resume:

1. **USB HID disconnection** — devices lose their HID handles and must be
   re-enumerated.
2. **WebSocket disconnection** — the plugin WebSocket server loses all active
   connections; neither the Elgato SDK nor the openaction SDK has built-in
   reconnection logic.
3. **Web Worker timer death** — webview plugins that use the Elgato SDK's
   `timers.js` have their `setTimeout`/`setInterval` overridden by a Web Worker.
   This Worker dies during sleep and does not resume, so even after WebSocket
   reconnection the plugin's timers (e.g. clock animations) remain frozen.

This PR adds a `system_sleep_watchdog` module that detects system sleep via
wall-clock monitoring and orchestrates a full recovery sequence on wake.

## Changes

### New: `system_sleep_watchdog.rs`
- Polls wall-clock time at 1 Hz; detects sleep when elapsed > 3 s between polls.
- On wake: waits 2 s for USB stabilisation → re-enumerates devices → wakes idle
  devices → broadcasts `systemDidWakeUp` to all plugins → reloads webview plugins.

### New: `events/outbound/misc.rs`
- `system_did_wake_up()` sends a `systemDidWakeUp` JSON event to every connected
  plugin (native and webview), matching the Elgato SDK convention so plugins can
  optionally react to wake events.

### Modified: `plugins/mod.rs`
- `reload_webview_plugins()` — for each webview plugin:
  1. `location.reload()` to get a fresh JS environment and new Web Worker.
  2. Hidden-iframe trick to restore native `setInterval`/`setTimeout` (the new
     Worker after reload may also be unreliable on some systems).
  3. Re-evaluate the SDK connection init JS to create a fresh WebSocket and send
     `registerPlugin`.
- Avoids closing/recreating the Tauri window, since `window.close()` does not
  reliably destroy webviews on Windows (causes "label already exists" panics).

### Modified: `main.rs`
- Register `system_sleep_watchdog` module and call `init_watchdog()` on startup.

## Performance Impact

The overhead is negligible:

- **CPU**: The watchdog sleeps on a tokio interval and wakes once per second to
  compare two `SystemTime` values — effectively a single syscall per second. No
  busy-waiting, no polling of device handles or file descriptors. On wake, device
  re-enumeration and webview reload are one-shot operations that complete in a few
  seconds and then go idle.
- **Memory**: One persistent tokio task (~100 bytes of state). The hidden iframe
  created per webview plugin is a lightweight DOM element that persists but
  consumes no CPU and negligible heap.
- **Network**: No additional network traffic. WebSocket reconnection reuses the
  existing localhost port.

In short, the idle-state cost is one 1 Hz timer tick; all heavier work only
happens during the brief wake-recovery window.

## Tested

- Windows 11, AKP153 + onairclock webview plugin.
- Confirmed recovery after 68-minute sleep: USB device responsive, webview clock
  ticking within seconds of wake.

## Suggestion

It may be worth documenting the `systemDidWakeUp` event in the plugin development
guide so that plugin authors are aware they can subscribe to it for their own
sleep-recovery logic. The event follows the Elgato SDK naming convention and
carries no payload:

```json
{ "event": "systemDidWakeUp" }
```

Native plugins could use it to re-open USB handles; webview plugins could use it
to rebuild application state — though for webview plugins, OpenDeck already
handles full reconnection automatically.

## Notes

- The wall-clock approach is deliberately simple and cross-platform — it does not
  depend on platform-specific power-event APIs.
- The 3 s threshold is well above the 1 s poll interval even with scheduler noise,
  so false positives are extremely unlikely.