### PR TITLE
fix: reapply device brightness after system resume

### DIFF
--- a/src-tauri/src/device_sleep.rs
+++ b/src-tauri/src/device_sleep.rs
@@ -16,6 +16,26 @@ pub fn is_device_sleeping(device: &str) -> bool {
 	SLEEPING_DEVICES.contains_key(device)
 }
 
+/// After the system resumes from sleep, device firmware has reset its brightness to 0, but
+/// OpenDeck's handles and software state are intact (devices are not re-enumerated). Re-push the
+/// configured brightness to every connected device that is not intentionally asleep (idle or
+/// computer-lock). Does not open/enumerate any device, so it is safe with respect to the macOS
+/// wake crash (which occurs in `hid_open`/`hid_enumerate`, not when writing to an open handle).
+pub async fn reapply_brightness_after_resume() -> Result<(), anyhow::Error> {
+	let brightness = crate::store::get_settings().value.brightness;
+	let devices = crate::shared::DEVICES.iter().map(|entry| entry.id.clone()).collect::<Vec<_>>();
+	let mut reapplied = 0;
+	for device in devices {
+		if is_device_sleeping(&device) {
+			continue;
+		}
+		crate::events::outbound::devices::set_device_brightness(&device, brightness).await?;
+		reapplied += 1;
+	}
+	log::info!("Reapplied brightness to {reapplied} device(s) after system resume");
+	Ok(())
+}
+
 pub fn init_device_sleep() {
 	SLEEP_TIMEOUT_MINUTES.store(crate::store::get_settings().value.sleep_timeout_minutes, Ordering::Relaxed);
 	SLEEP_WHEN_COMPUTER_LOCKED.store(crate::store::get_settings().value.sleep_when_computer_locked, Ordering::Relaxed);

--- a/src-tauri/src/power_events.rs
+++ b/src-tauri/src/power_events.rs
@@ -30,6 +30,9 @@ pub fn init_power_events() {
 						if let Err(error) = crate::events::outbound::misc::system_did_wake_up().await {
 							log::error!("Failed to send the systemDidWakeUp event: {error}");
 						}
+						if let Err(error) = crate::device_sleep::reapply_brightness_after_resume().await {
+							log::error!("Failed to reapply device brightness after resume: {error}");
+						}
 					});
 				}
 				PowerState::Suspend | PowerState::Shutdown | PowerState::Unknown => {}


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---

## Summary

After the machine resumes from suspend, a connected Stream Deck's screen stays **black**
(brightness 0%) until the user manually moves the brightness slider.

**Root cause.** On resume, the device firmware resets its brightness to 0, but the OS does
*not* re-enumerate the device — OpenDeck's HID handle and software state remain valid (the
read loop in `elgato::init` merely keeps timing out, never erroring, so the device is never
torn down and re-initialised). Power monitoring (added in #325 via `psp`) already detects the
resume, but the `PowerState::Resume` handler only broadcasts `systemDidWakeUp` to plugins —
nothing re-pushes brightness to the devices. So the panel stays dark.

This follows up on the discussion in #357, where re-doing device wake recovery "using the
proper power monitoring afforded by psp" was suggested.

## Changes

- **`device_sleep.rs`**: add `reapply_brightness_after_resume()`, which re-pushes the
  configured brightness to every connected device that is not intentionally asleep
  (`is_device_sleeping` — i.e. idle-timeout or computer-lock sleep are respected and left off).
- **`power_events.rs`**: call it from the `PowerState::Resume` arm, alongside the existing
  `systemDidWakeUp` broadcast.

It re-uses `set_device_brightness`, so it also covers non-Elgato plugin devices. It writes
only to already-open handles — it never enumerates or opens a device — so it stays clear of
the macOS wake path being addressed in #354.

## Testing

- Linux (Wayland + systemd-logind), Stream Deck Plus.
- Before: real `systemctl suspend` / resume → screen stays black (reproduced on current
  `main`).
- After: real suspend / resume → screen returns to the configured brightness within ~1 s,
  without any user interaction. Confirmed in the log:
  `Reapplied brightness to 1 device(s) after system resume`.
- `cargo fmt` applied; no unrelated changes.

Not yet tested on Windows/macOS; the change is platform-agnostic (driven by `psp`) and avoids
the macOS enumerate/open path, so I do not expect platform-specific issues, but confirmation
on those platforms is welcome.
