### PR TITLE
Ensure all encoder loads follow the same path

### DIFF
--- a/src-tauri/src/events/frontend/instances.rs
+++ b/src-tauri/src/events/frontend/instances.rs
@@ -13,7 +13,7 @@ pub async fn create_instance(app: AppHandle, mut action: Action, context: Contex
 	}
 
 	if context.controller == "Encoder" {
-		let _ = crate::shared::load_encoder(&mut action, None);
+		let _ = crate::shared::initialise_encoder_layout(&mut action, None);
 	}
 
 	let mut locks = acquire_locks_mut().await;

--- a/src-tauri/src/events/frontend/instances.rs
+++ b/src-tauri/src/events/frontend/instances.rs
@@ -13,7 +13,7 @@ pub async fn create_instance(app: AppHandle, mut action: Action, context: Contex
 	}
 
 	if context.controller == "Encoder" {
-		crate::shared::load_initial_encoder_layout(&mut action);
+		let _ = crate::shared::load_encoder(&mut action, None);
 	}
 
 	let mut locks = acquire_locks_mut().await;

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -226,7 +226,7 @@ pub async fn set_feedback_layout(event: ContextAndPayloadEvent<SetFeedbackLayout
 	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
 		// We need to replace the existing parsed layout with the new one
 		let layout_name = event.payload.layout.clone();
-		crate::shared::load_encoder(&mut instance.action, Some(layout_name))?;
+		crate::shared::initialise_encoder_layout(&mut instance.action, Some(layout_name))?;
 
 		// Trigger a state update; should cause a redraw
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -1,7 +1,6 @@
 use super::ContextAndPayloadEvent;
 
 use crate::events::frontend::instances::update_state;
-use crate::shared::{config_dir, load_encoder_layout};
 use crate::store::profiles::{acquire_locks_mut, debounce_profile_save, get_instance_mut, save_profile};
 
 use anyhow::bail;
@@ -224,28 +223,10 @@ pub async fn set_feedback(event: ContextAndPayloadEvent<Value>) -> Result<(), an
 
 pub async fn set_feedback_layout(event: ContextAndPayloadEvent<SetFeedbackLayoutPayload>) -> Result<(), anyhow::Error> {
 	let mut locks = acquire_locks_mut().await;
-	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await?
-		&& let Some(encoder) = &mut instance.action.encoder
-	{
+	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
 		// We need to replace the existing parsed layout with the new one
 		let layout_name = event.payload.layout.clone();
-
-		// Make sure the layout is a full path to the JSON file
-		let layout = if !encoder.layout.starts_with("$") {
-			let path = config_dir().join("plugins").join(&instance.action.plugin);
-
-			let layout_path = path.join(&layout_name).canonicalize()?;
-			if layout_path.starts_with(&path) {
-				layout_path.to_string_lossy().to_string()
-			} else {
-				// SetFeedbackLayout is sending a path outside our plugin; abort
-				bail!("Encoder layout path is outside plugin directory: {}", encoder.layout);
-			}
-		} else {
-			layout_name
-		};
-
-		encoder.layout_parsed = load_encoder_layout(&layout)?;
+		crate::shared::load_encoder(&mut instance.action, Some(layout_name))?;
 
 		// Trigger a state update; should cause a redraw
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -8,7 +8,6 @@ use serde_inline_default::serde_inline_default;
 
 use anyhow::{Result, bail};
 use dashmap::DashMap;
-use log::warn;
 use tauri::Manager;
 use tokio::sync::RwLock;
 
@@ -254,36 +253,35 @@ pub struct Encoder {
 	pub layout_parsed: serde_json::Value,
 }
 
-pub fn load_initial_encoder_layout(action: &mut Action) {
-	let Some(encoder) = action.encoder.as_mut() else { return };
+pub fn load_encoder(action: &mut Action, layout: Option<String>) -> Result<(), anyhow::Error> {
+	let Some(encoder) = action.encoder.as_mut() else { return Ok(()) };
 
-	let layout = if encoder.layout.starts_with('$') {
-		encoder.layout.clone()
+	let load_layout = layout.unwrap_or_else(|| encoder.layout.clone());
+	let layout = if load_layout.starts_with('$') {
+		load_layout.clone()
 	} else {
 		let plugin_dir = config_dir().join("plugins").join(&action.plugin);
-		let layout_file = plugin_dir.join(&encoder.layout);
+		let layout_file = plugin_dir.join(&load_layout);
 
 		match layout_file.canonicalize() {
 			Ok(resolved) if resolved.starts_with(&plugin_dir) => resolved.to_string_lossy().into_owned(),
 			Ok(_) => {
-				warn!("Encoder layout path escapes plugin directory: {}", encoder.layout);
-				return;
+				bail!("Encoder layout path escapes plugin directory: {}", load_layout);
 			}
 			Err(error) => {
-				warn!("Failed to canonicalize encoder layout path {}: {}", encoder.layout, error);
-				return;
+				bail!("Failed to canonicalize encoder layout path {}: {}", load_layout, error);
 			}
 		}
 	};
 
 	match load_encoder_layout(&layout) {
 		Ok(parsed) => encoder.layout_parsed = parsed,
-		Err(error) => warn!("Failed to load encoder layout {}: {}", encoder.layout, error),
+		Err(error) => bail!("Failed to load encoder layout {}: {}", load_layout, error),
 	}
+	Ok(())
 }
 
-// This can be called from plugins/mod.rs; it can also be called from a setFeedbackLayout request
-pub fn load_encoder_layout(layout: &str) -> Result<serde_json::Value> {
+fn load_encoder_layout(layout: &str) -> Result<serde_json::Value> {
 	match layout {
 		"$A0" => Ok(serde_json::from_str(include_str!("../../static/encoder_layouts/A0.json"))?),
 		"$A1" => Ok(serde_json::from_str(include_str!("../../static/encoder_layouts/A1.json"))?),

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -253,7 +253,7 @@ pub struct Encoder {
 	pub layout_parsed: serde_json::Value,
 }
 
-pub fn load_encoder(action: &mut Action, layout: Option<String>) -> Result<(), anyhow::Error> {
+pub fn initialise_encoder_layout(action: &mut Action, layout: Option<String>) -> Result<(), anyhow::Error> {
 	let Some(encoder) = action.encoder.as_mut() else { return Ok(()) };
 
 	let load_layout = layout.unwrap_or_else(|| encoder.layout.clone());

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -1,6 +1,6 @@
 use super::Store;
 
-use crate::shared::{ActionInstance, DEVICES, DeviceInfo, Profile, config_dir, copy_dir, load_initial_encoder_layout};
+use crate::shared::{ActionInstance, DEVICES, DeviceInfo, Profile, config_dir, copy_dir, load_encoder};
 
 use std::collections::HashMap;
 use std::fs;
@@ -75,7 +75,7 @@ impl ProfileStores {
 				}
 
 				// Load encoder layout if not yet parsed
-				load_initial_encoder_layout(&mut instance.action);
+				let _ = load_encoder(&mut instance.action, None);
 			}
 
 			store.save()?;

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -1,6 +1,6 @@
 use super::Store;
 
-use crate::shared::{ActionInstance, DEVICES, DeviceInfo, Profile, config_dir, copy_dir, load_encoder};
+use crate::shared::{ActionInstance, DEVICES, DeviceInfo, Profile, config_dir, copy_dir, initialise_encoder_layout};
 
 use std::collections::HashMap;
 use std::fs;
@@ -75,7 +75,7 @@ impl ProfileStores {
 				}
 
 				// Load encoder layout if not yet parsed
-				let _ = load_encoder(&mut instance.action, None);
+				let _ = initialise_encoder_layout(&mut instance.action, None);
 			}
 
 			store.save()?;


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [X] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [X] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [X] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [X] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [X] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [X] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [X] I will keep "Allow edits from maintainers" enabled for this pull request.

---
Sorry, one more. This change ensures that all attempts to load encoder layouts follow the same code path, keeping everything (including path validation) central.