### PR TITLE
Handle image path expansion and validation inside OpenDeck

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5394,7 +5394,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "streamdeck-strip-render"
 version = "0.1.0"
-source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=5a18406c#5a18406c3f7560f4f4220756e7da459d76559946"
+source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=9347f48c#9347f48cab0dd999b07f3409dcb4296864332492"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5394,7 +5394,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "streamdeck-strip-render"
 version = "0.1.0"
-source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=3fd04b41#3fd04b41e895694a19228ef1c3d90f9e971c8aa2"
+source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=9067d1ad#9067d1ad960715e2e5988165dbbd9f84d69aa35c"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5394,7 +5394,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "streamdeck-strip-render"
 version = "0.1.0"
-source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=9347f48c#9347f48cab0dd999b07f3409dcb4296864332492"
+source = "git+https://github.com/FrostyCoolSlug/streamdeck-strip-render?rev=3fd04b41#3fd04b41e895694a19228ef1c3d90f9e971c8aa2"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tiny_http = "0.12"
 elgato-streamdeck = { version = "0.12", default-features = false, features = ["async"] }
 hidapi = "2.6"
 image = { version = "0.25", default-features = false, features = ["bmp", "jpeg"] }
-streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "3fd04b41" }
+streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "9067d1ad" }
 
 # Smaller utility libraries
 dashmap = { version = "6.1", features = ["serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tiny_http = "0.12"
 elgato-streamdeck = { version = "0.12", default-features = false, features = ["async"] }
 hidapi = "2.6"
 image = { version = "0.25", default-features = false, features = ["bmp", "jpeg"] }
-streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "5a18406c" }
+streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "9347f48c" }
 
 # Smaller utility libraries
 dashmap = { version = "6.1", features = ["serde"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ tiny_http = "0.12"
 elgato-streamdeck = { version = "0.12", default-features = false, features = ["async"] }
 hidapi = "2.6"
 image = { version = "0.25", default-features = false, features = ["bmp", "jpeg"] }
-streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "9347f48c" }
+streamdeck-strip-render = { git = "https://github.com/FrostyCoolSlug/streamdeck-strip-render", rev = "3fd04b41" }
 
 # Smaller utility libraries
 dashmap = { version = "6.1", features = ["serde"] }

--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -13,6 +13,7 @@ use elgato_streamdeck::{
 	info::Kind,
 };
 use image::{DynamicImage, GenericImageView as _};
+use log::warn;
 use serde_json::Value;
 use tokio::sync::RwLock;
 
@@ -38,6 +39,7 @@ fn get_encoder_image(encoder: &Encoder, instance: &ActionInstance) -> Result<Dyn
 	}
 
 	let path = config_dir().join("plugins").join(&instance.action.plugin);
+	let path_canonical = path.canonicalize()?;
 
 	// We need to validate whether title text and icon images are defined; if not, pull them from the state/action
 	if let Some(items_array) = layout.get_mut("items").and_then(Value::as_array_mut) {
@@ -55,6 +57,32 @@ fn get_encoder_image(encoder: &Encoder, instance: &ActionInstance) -> Result<Dyn
 				// If the state title is empty, fall back to the action name
 				let title = state_text.unwrap_or(instance.action.name.as_str());
 				title_item["value"] = Value::String(title.to_string());
+			}
+		}
+
+		// Expand all image paths in the layout and confirm they're in the plugin
+		for item in items_array.iter_mut() {
+			if item["type"] == "pixmap"
+				&& let Some(v) = item["value"].as_str()
+				&& !v.is_empty()
+				&& !v.starts_with("data:")
+				&& {
+					let t = v.trim_start();
+					!(t.starts_with("<svg") || (t.starts_with("<?xml") && t.contains("<svg")))
+				} {
+				let final_path = path.join(v);
+
+				if let Ok(path) = final_path.canonicalize() {
+					if path.starts_with(&path_canonical) {
+						item["value"] = Value::String(path.to_string_lossy().into_owned());
+					} else {
+						warn!("Attempted to load image outside of base path: {:?}", path);
+						item["value"] = Value::String(String::new());
+					}
+				} else {
+					warn!("Unable to canonicalize path: {:?}", final_path);
+					item["value"] = Value::String(String::new());
+				}
 			}
 		}
 
@@ -76,7 +104,7 @@ fn get_encoder_image(encoder: &Encoder, instance: &ActionInstance) -> Result<Dyn
 		}
 	}
 
-	streamdeck_strip_render::render_to_image(layout, &path, None)
+	streamdeck_strip_render::render_to_image(layout, None)
 }
 
 pub async fn update_image(context: &crate::shared::Context, image: Option<&str>) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -45,19 +45,14 @@ fn get_encoder_image(encoder: &Encoder, instance: &ActionInstance) -> Result<Dyn
 	if let Some(items_array) = layout.get_mut("items").and_then(Value::as_array_mut) {
 		// If the title is missing, provide it from the state/action
 		if let Some(title_item) = items_array.iter_mut().find(|item| item.get("key").and_then(Value::as_str) == Some("title")) {
-			let title_value = title_item.get("value").and_then(Value::as_str).unwrap_or("").trim();
+			let state = instance.states[instance.current_state as usize].text.trim();
 
-			if title_value.is_empty() {
-				// Try to pull the title from the state
-				let state_text = instance.states.get(instance.current_state as usize).and_then(|s| {
-					let t = s.text.trim();
-					if t.is_empty() { None } else { Some(t) }
-				});
-
-				// If the state title is empty, fall back to the action name
-				let title = state_text.unwrap_or(instance.action.name.as_str());
-				title_item["value"] = Value::String(title.to_string());
-			}
+			let title = if !state.is_empty() {
+				state
+			} else {
+				title_item.get("value").and_then(Value::as_str).unwrap_or(&instance.action.name).trim()
+			};
+			title_item["value"] = Value::String(title.to_string());
 		}
 
 		// Expand all image paths in the layout and confirm they're in the plugin
@@ -88,19 +83,17 @@ fn get_encoder_image(encoder: &Encoder, instance: &ActionInstance) -> Result<Dyn
 
 		// If the icon is missing, provide it from the state/action
 		if let Some(icon_item) = items_array.iter_mut().find(|item| item.get("key").and_then(Value::as_str) == Some("icon")) {
-			let icon_empty = icon_item.get("value").and_then(Value::as_str).is_none_or(str::is_empty);
-			if icon_empty {
-				let icon = instance
-					.states
-					.get(instance.current_state as usize)
-					.map(|state| &state.image)
-					.filter(|image| !image.is_empty())
-					.unwrap_or(&instance.action.icon);
+			// We need to compare this states icon with the default icon for this state
+			let state = &instance.states[instance.current_state as usize];
+			let default = &instance.action.states[instance.current_state as usize];
 
-				if !icon.is_empty() {
-					icon_item["value"] = Value::String(icon.clone());
-				}
-			}
+			let override_image = state.image != default.image;
+			let icon = if override_image && !state.image.is_empty() {
+				state.image.trim()
+			} else {
+				icon_item.get("value").and_then(Value::as_str).unwrap_or(&instance.action.icon).trim()
+			};
+			icon_item["value"] = Value::String(icon.to_string());
 		}
 	}
 


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [X] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [X] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [X] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [X] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [X] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [X] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [X] I will keep "Allow edits from maintainers" enabled for this pull request.

---
This moves the path expansion and validation from the render lib to OpenDeck.

A bug was found where loading a custom icon of an action on startup loads the icon from `.config/opendeck/images/SD-.../x.svg`, which when passed in to the renderer was causing an 'Attempted to load image outside of base path' error.

This code moves the validation out of the renderer and into OpenDeck as it's better suited to make the determination over whether a path is acceptable or not.