### PR TITLE
fix: always answer getSettings

### DIFF
--- a/src-tauri/src/events/inbound/mod.rs
+++ b/src-tauri/src/events/inbound/mod.rs
@@ -80,7 +80,6 @@ pub async fn process_incoming_message(data: Result<Message, Error>, uuid: &str, 
 		if !(uuid.is_empty() && skip_auth) {
 			if let Some(context) = match &decoded {
 				InboundEventType::SetSettings(event) => Some(&event.context),
-				InboundEventType::GetSettings(event) => Some(&event.context),
 				InboundEventType::SetTitle(event) => Some(&event.context),
 				InboundEventType::SetImage(event) => Some(&event.context),
 				InboundEventType::SetState(event) => Some(&event.context),
@@ -123,7 +122,7 @@ pub async fn process_incoming_message(data: Result<Message, Error>, uuid: &str, 
 			InboundEventType::EncoderUp(event) => devices::encoder_up(event).await,
 			InboundEventType::TouchscreenPress(event) => devices::touchscreen_press(event).await,
 			InboundEventType::SetSettings(event) => settings::set_settings(event, false).await,
-			InboundEventType::GetSettings(event) => settings::get_settings(event, false).await,
+			InboundEventType::GetSettings(event) => settings::get_settings(event, false, uuid).await,
 			InboundEventType::SetGlobalSettings(event) => settings::set_global_settings(event, false).await,
 			InboundEventType::GetGlobalSettings(event) => settings::get_global_settings(event, false).await,
 			InboundEventType::OpenUrl(event) => misc::open_url(event).await,
@@ -167,7 +166,7 @@ pub async fn process_incoming_message_pi(data: Result<Message, Error>, uuid: &st
 
 		if let Err(error) = match decoded {
 			InboundEventType::SetSettings(event) => settings::set_settings(event, true).await,
-			InboundEventType::GetSettings(event) => settings::get_settings(event, true).await,
+			InboundEventType::GetSettings(event) => settings::get_settings(event, true, uuid).await,
 			InboundEventType::SetGlobalSettings(event) => settings::set_global_settings(event, true).await,
 			InboundEventType::GetGlobalSettings(event) => settings::get_global_settings(event, true).await,
 			InboundEventType::OpenUrl(event) => misc::open_url(event).await,

--- a/src-tauri/src/events/inbound/settings.rs
+++ b/src-tauri/src/events/inbound/settings.rs
@@ -20,11 +20,11 @@ pub async fn set_settings(event: super::ContextAndPayloadEvent<serde_json::Value
 pub async fn get_settings(event: super::ContextEvent, from_property_inspector: bool, requester: &str) -> Result<(), anyhow::Error> {
 	let locks = acquire_locks().await;
 
-	if let Some(instance) = get_instance(&event.context, &locks).await? {
-		if from_property_inspector || instance.action.plugin == requester {
-			outbound::did_receive_settings(instance, from_property_inspector).await?;
-			return Ok(());
-		}
+	if let Some(instance) = get_instance(&event.context, &locks).await?
+		&& (from_property_inspector || instance.action.plugin == requester)
+	{
+		outbound::did_receive_settings(instance, from_property_inspector).await?;
+		return Ok(());
 	}
 
 	outbound::did_receive_settings_fallback(requester, &event.context, from_property_inspector).await?;

--- a/src-tauri/src/events/inbound/settings.rs
+++ b/src-tauri/src/events/inbound/settings.rs
@@ -17,12 +17,17 @@ pub async fn set_settings(event: super::ContextAndPayloadEvent<serde_json::Value
 	Ok(())
 }
 
-pub async fn get_settings(event: super::ContextEvent, from_property_inspector: bool) -> Result<(), anyhow::Error> {
+pub async fn get_settings(event: super::ContextEvent, from_property_inspector: bool, requester: &str) -> Result<(), anyhow::Error> {
 	let locks = acquire_locks().await;
 
 	if let Some(instance) = get_instance(&event.context, &locks).await? {
-		outbound::did_receive_settings(instance, from_property_inspector).await?;
+		if from_property_inspector || instance.action.plugin == requester {
+			outbound::did_receive_settings(instance, from_property_inspector).await?;
+			return Ok(());
+		}
 	}
+
+	outbound::did_receive_settings_fallback(requester, &event.context, from_property_inspector).await?;
 
 	Ok(())
 }

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -52,6 +52,27 @@ impl GenericInstancePayload {
 			isInMultiAction: instance.context.index != 0,
 		}
 	}
+
+	fn empty(context: &crate::shared::ActionContext) -> Self {
+		let coordinates = match &context.controller[..] {
+			"Encoder" => Coordinates { row: 0, column: context.position },
+			_ => match crate::shared::DEVICES.get(&context.device) {
+				Some(device) => Coordinates {
+					row: context.position / device.columns,
+					column: context.position % device.columns,
+				},
+				None => Coordinates { row: 0, column: 0 },
+			},
+		};
+
+		Self {
+			settings: serde_json::Value::Object(serde_json::Map::new()),
+			coordinates,
+			controller: context.controller.clone(),
+			state: 0,
+			isInMultiAction: context.index != 0,
+		}
+	}
 }
 
 async fn send_to_plugin(plugin: &str, data: &impl Serialize) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/events/outbound/mod.rs
+++ b/src-tauri/src/events/outbound/mod.rs
@@ -18,6 +18,21 @@ struct Coordinates {
 	column: u8,
 }
 
+impl Coordinates {
+	fn from_context(context: &crate::shared::ActionContext) -> Self {
+		if context.controller == "Encoder" {
+			return Coordinates { row: 0, column: context.position };
+		}
+		match crate::shared::DEVICES.get(&context.device) {
+			Some(device) if device.columns > 0 => Coordinates {
+				row: context.position / device.columns,
+				column: context.position % device.columns,
+			},
+			_ => Coordinates { row: 0, column: 0 },
+		}
+	}
+}
+
 #[derive(Serialize)]
 #[allow(non_snake_case)]
 struct GenericInstancePayload {
@@ -30,23 +45,9 @@ struct GenericInstancePayload {
 
 impl GenericInstancePayload {
 	fn new(instance: &crate::shared::ActionInstance) -> Self {
-		let coordinates = match &instance.context.controller[..] {
-			"Encoder" => Coordinates {
-				row: 0,
-				column: instance.context.position,
-			},
-			_ => {
-				let columns = crate::shared::DEVICES.get(&instance.context.device).unwrap().columns;
-				Coordinates {
-					row: instance.context.position / columns,
-					column: instance.context.position % columns,
-				}
-			}
-		};
-
 		Self {
 			settings: instance.settings.clone(),
-			coordinates,
+			coordinates: Coordinates::from_context(&instance.context),
 			controller: instance.context.controller.clone(),
 			state: instance.current_state,
 			isInMultiAction: instance.context.index != 0,
@@ -54,20 +55,9 @@ impl GenericInstancePayload {
 	}
 
 	fn empty(context: &crate::shared::ActionContext) -> Self {
-		let coordinates = match &context.controller[..] {
-			"Encoder" => Coordinates { row: 0, column: context.position },
-			_ => match crate::shared::DEVICES.get(&context.device) {
-				Some(device) => Coordinates {
-					row: context.position / device.columns,
-					column: context.position % device.columns,
-				},
-				None => Coordinates { row: 0, column: 0 },
-			},
-		};
-
 		Self {
 			settings: serde_json::Value::Object(serde_json::Map::new()),
-			coordinates,
+			coordinates: Coordinates::from_context(context),
 			controller: context.controller.clone(),
 			state: 0,
 			isInMultiAction: context.index != 0,

--- a/src-tauri/src/events/outbound/settings.rs
+++ b/src-tauri/src/events/outbound/settings.rs
@@ -30,6 +30,21 @@ pub async fn did_receive_settings(instance: &crate::shared::ActionInstance, to_p
 	}
 }
 
+pub async fn did_receive_settings_fallback(plugin: &str, context: &ActionContext, to_property_inspector: bool) -> Result<(), anyhow::Error> {
+	let data = DidReceiveSettingsEvent {
+		event: "didReceiveSettings",
+		action: String::new(),
+		context: context.clone(),
+		device: context.device.clone(),
+		payload: GenericInstancePayload::empty(context),
+	};
+	if to_property_inspector {
+		send_to_property_inspector(context, &data).await
+	} else {
+		send_to_plugin(plugin, &data).await
+	}
+}
+
 #[derive(Serialize)]
 struct DidReceiveGlobalSettingsPayload {
 	settings: serde_json::Value,


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---
This makes `getSettings` always reply even if we're in a fresh context. Some plugins, in my case https://github.com/ciderapp/CiderDeck, unconditionally expect this to reply (and it appears the official StreamDeck program _does_) and will get stuck in a crash loop when it doesn't exist. 

Once the plugin + OpenDeck are fully initialized it's fine, just initial boot dies. 