### PR TITLE
fix: ignore --hide relaunches in single-instance callback to respect background startup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -346,7 +346,7 @@ If you have already donated, thank you so much for your support!"#,
 								tauri::async_runtime::block_on(events::inbound::process_incoming_message(Ok(tokio_tungstenite::tungstenite::Message::Text(message.into())), "", true));
 							});
 						}
-					} else {
+					} else if !args.iter().any(|x| x.to_lowercase().trim() == "--hide") {
 						let _ = show_window(app);
 					}
 				})

--- a/translations/de.json
+++ b/translations/de.json
@@ -114,7 +114,7 @@
 	"settings.autolaunch.tooltip.1": "Wenn diese Option aktiviert ist, wird {{PRODUCT_NAME}} automatisch beim Anmelden gestartet.",
 	"settings.autolaunch.tooltip.2": "Wenn du {{PRODUCT_NAME}} mit Flatpak installiert hast, funktioniert diese Option möglicherweise nicht wie vorgesehen",
 	"settings.background": "Im Hintergrund weiterlaufen lassen:",
-	"settings.background.tooltip": "Wenn diese Option aktiviert ist, wird {{PRODUCT_NAME}} in das System-Tray minimiert und im Hintergrund ausgeführt.",
+	"settings.background.tooltip": "Wenn diese Option aktiviert ist, wird {{PRODUCT_NAME}} beim Schließen des Fensters in das System-Tray minimiert, anstatt die Anwendung zu beenden. Dies hat keinen Einfluss darauf, ob das Fenster beim Start von {{PRODUCT_NAME}} angezeigt wird.",
 	"settings.backup_config.button": "Konfiguration sichern",
 	"settings.backup_config.prompt": "Du wirst aufgefordert, einen Speicherort zum Speichern der Sicherung auszuwählen. Der Konfigurationsordner wird komprimiert und dort gespeichert. Dies kann eine Weile dauern, wenn du viele Plugins oder Profile hast.",
 	"settings.backup_config.success.prompt": "Die Konfiguration wurde erfolgreich gesichert.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -114,7 +114,7 @@
 	"settings.autolaunch.tooltip.1": "If this option is enabled, {{PRODUCT_NAME}} will automatically start at login.",
 	"settings.autolaunch.tooltip.2": "If you used Flatpak to install {{PRODUCT_NAME}}, this option may not function as intended.",
 	"settings.background": "Run in background:",
-	"settings.background.tooltip": "If this option is enabled, {{PRODUCT_NAME}} will minimise to the tray and run in the background.",
+	"settings.background.tooltip": "If this option is enabled, closing the {{PRODUCT_NAME}} window will minimise it to the tray instead of quitting the application. This does not affect whether the window is shown when {{PRODUCT_NAME}} starts.",
 	"settings.backup_config.button": "Back up config",
 	"settings.backup_config.prompt": "You will be prompted to select a location to save the backup to. The config directory will be compressed and saved there. This may take a while if you have many plugins or profiles.",
 	"settings.backup_config.success.prompt": "Successfully backed up the config directory.",


### PR DESCRIPTION
Fixes #380

## Summary

- Autostart launches OpenDeck with `--hide`. If an instance is already running (e.g. leftover from a previous session, or DE-specific autostart/session-restore timing — more likely on KDE Plasma), the `tauri_plugin_single_instance` callback receives the relaunch args in the already-running process.
- None of the callback's recognised argument branches matched `--hide`, so it fell through to the final `else`, which unconditionally called `show_window(app)` — forcing the window visible regardless of the "Run in background" setting.
- Also clarified the "Run in background" tooltip (EN + DE), which only ever governs close-button behaviour (minimise to tray vs. quit), not startup visibility — the previous wording implied it controlled whether the app starts hidden.

## Test plan

- [x] `cargo clippy` / `cargo fmt` clean
- [x] `deno lint` / `deno task check` / `deno task format` clean
- [x] Built release binary locally, ran with `--hide` as first instance — window stays hidden (verified via temporary debug logging, removed before commit)
- [x] Ran a second `--hide` launch while the first instance was still running — confirmed the single-instance callback now skips `show_window` instead of forcing the window open