### PR TITLE
fix: preserve plugin-set key images across profile re-renders

### DIFF
--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -27,8 +27,11 @@
 	// One-way binding for slot data.
 	export let inslot: ActionInstance | null;
 	let slot: ActionInstance | null;
+	let lastInslot: ActionInstance | null | undefined;
 	const update = (inslot: ActionInstance | null) => {
+		if (inslot === lastInslot) return;
 		if (inslot && context && inslot.context.split(".")[0] != context.device) return;
+		lastInslot = inslot;
 		slot = inslot;
 	};
 	$: update(inslot);


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---

Fixes #386.

> Related to #152 — the same symptom (a key showing the wrong image) but a distinct
> cause. #152 is a device reconnect (a backend reload from disk); this fixes a purely
> frontend re-render and does not address the reconnect case.

### Problem

When a plugin updates a key's image via `setImage`, the update is discarded on the
next profile grid re-render (e.g. after adding or moving any action), and the key
reverts to the image the profile was loaded with. No reconnect is involved.

### Cause

`slot` is a Key's local working copy; `inslot` is the deliberate one-way downward
channel from `profile.keys[]` (a plugin's per-session `setImage` writes only `slot`,
never `profile`). On `profile = profile`, Svelte's `safe_not_equal` treats an
identical object reference as changed, so the reactive `$: update(inslot)` re-runs for
every key even when its `profile.keys[i]` didn't change; `update()` then
unconditionally does `slot = inslot`, resetting the key to the loaded instance and
discarding the plugin's image.

### Fix

Make `update()` idempotent: remember the last bound reference and skip the reset when
`inslot` hasn't actually changed. The one-way `inslot`/`slot` split stays intact —
nothing propagates upward into `profile` — while a genuine change (a fresh instance
from the backend, or the `update_state` listener) still applies.

```diff
 	// One-way binding for slot data.
 	export let inslot: ActionInstance | null;
 	let slot: ActionInstance | null;
+	let lastInslot: ActionInstance | null | undefined;
 	const update = (inslot: ActionInstance | null) => {
+		if (inslot === lastInslot) return;
 		if (inslot && context && inslot.context.split(".")[0] != context.device) return;
+		lastInslot = inslot;
 		slot = inslot;
 	};
 	$: update(inslot);
```

The latch sits after the device filter, so a filtered entry is re-evaluated on the
next pass exactly as before, and `clear()`'s upward `null` still round-trips.

### Testing

- With a plugin that updates a key image via `setImage`: set an image, restarted so
  the profile loads it, set a different image this session, then added/moved another
  action — the update now persists (previously the key reverted to the loaded image).
- Keys whose image matches the loaded profile continue to render correctly.
- `deno task check` and prettier are clean.