### PR TITLE
feat: Improve language combo to be more dynamic and grow with the longest language

### DIFF
--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -18,16 +18,6 @@
 
 	let showPopup: boolean;
 	let buildInfo: string;
-	const languageOptions = [
-		{ value: "en", label: "English" },
-		{ value: "es", label: "Español" },
-		{ value: "zh_CN", label: "中文" },
-		{ value: "fr", label: "Français" },
-		{ value: "de", label: "Deutsch" },
-		{ value: "ja", label: "日本語" },
-		{ value: "ko", label: "韓国語" }
-	];
-
 	(async () => (buildInfo = await invoke("get_build_info")))();
 
 	listen("device_brightness", ({ payload }: { payload: { action: string; value: number } }) => {
@@ -81,9 +71,13 @@
 			<label for="settings-language" class="text-neutral-400">{$t("settings.language")}</label>
 			<div class="select-wrapper">
 				<select bind:value={$settings.language} class="w-auto" style="padding-right: 2.5em;" id="settings-language">
-					{#each languageOptions as option}
-						<option value={option.value}>{option.label}</option>
-					{/each}
+					<option value="en">English</option>
+					<option value="es">Español</option>
+					<option value="zh_CN">中文</option>
+					<option value="fr">Français</option>
+					<option value="de">Deutsch</option>
+					<option value="ja">日本語</option>
+					<option value="ko">韓国語</option>
 				</select>
 			</div>
 			<Tooltip>

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -18,6 +18,16 @@
 
 	let showPopup: boolean;
 	let buildInfo: string;
+	const languageOptions = [
+		{ value: "en", label: "English" },
+		{ value: "es", label: "Español" },
+		{ value: "zh_CN", label: "中文" },
+		{ value: "fr", label: "Français" },
+		{ value: "de", label: "Deutsch" },
+		{ value: "ja", label: "日本語" },
+		{ value: "ko", label: "韓国語" }
+	];
+
 	(async () => (buildInfo = await invoke("get_build_info")))();
 
 	listen("device_brightness", ({ payload }: { payload: { action: string; value: number } }) => {
@@ -70,14 +80,10 @@
 		<div class="flex flex-row items-center m-2 space-x-2">
 			<label for="settings-language" class="text-neutral-400">{$t("settings.language")}</label>
 			<div class="select-wrapper">
-				<select bind:value={$settings.language} class="w-32" id="settings-language">
-					<option value="en">English</option>
-					<option value="es">Español</option>
-					<option value="zh_CN">中文</option>
-					<option value="fr">Français</option>
-					<option value="de">Deutsch</option>
-					<option value="ja">日本語</option>
-					<option value="ko">韓国語</option>
+				<select bind:value={$settings.language} class="w-auto" style="padding-right: 2.5em;" id="settings-language">
+					{#each languageOptions as option}
+						<option value={option.value}>{option.label}</option>
+					{/each}
 				</select>
 			</div>
 			<Tooltip>

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -70,7 +70,7 @@
 		<div class="flex flex-row items-center m-2 space-x-2">
 			<label for="settings-language" class="text-neutral-400">{$t("settings.language")}</label>
 			<div class="select-wrapper">
-				<select bind:value={$settings.language} class="w-auto" style="padding-right: 2.5em;" id="settings-language">
+				<select bind:value={$settings.language} class="w-auto pr-10!" id="settings-language">
 					<option value="en">English</option>
 					<option value="es">Español</option>
 					<option value="zh_CN">中文</option>


### PR DESCRIPTION
## Rationale

- Improve language combo ui to dynamically support longer names and load the combo dynamically from a js object

## Images

|Before|After|
|-|-|
|<img width="412" height="129" alt="image" src="https://github.com/user-attachments/assets/cc4285c3-645b-4f1e-a8b8-b3e75e7f56bf" />|<img width="460" height="126" alt="image" src="https://github.com/user-attachments/assets/c63f3084-aed5-4f6f-b002-43190fe06dda" />|

### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---
