### PR TITLE
feat (#394): add support for navigating to previous profiles using an in-memory history stack

### DIFF
--- a/plugins/com.amansprojects.starterpack.sdPlugin/assets/propertyInspector/switchProfile.html
+++ b/plugins/com.amansprojects.starterpack.sdPlugin/assets/propertyInspector/switchProfile.html
@@ -69,16 +69,19 @@
 		</div>
 		<div class="sdpi-item">
 			<div class="sdpi-item-label" id="up-label">Profile</div>
-			<input id="profile" oninput="update()" class="sdpi-item-value" />
+			<input id="profile" list="profile-suggestions" oninput="update()" class="sdpi-item-value" placeholder="Profile name or __PREVIOUS__" />
+			<datalist id="profile-suggestions">
+				<option value="__PREVIOUS__">Previous Profile</option>
+			</datalist>
 		</div>
 		<div id="encoder" style="display: none">
 			<div class="sdpi-item">
 				<div class="sdpi-item-label">Dial rotate anticlockwise</div>
-				<input id="anticlockwise" oninput="update()" class="sdpi-item-value" />
+				<input id="anticlockwise" list="profile-suggestions" oninput="update()" class="sdpi-item-value" placeholder="Profile name or __PREVIOUS__" />
 			</div>
 			<div class="sdpi-item">
 				<div class="sdpi-item-label">Dial rotate clockwise</div>
-				<input id="clockwise" oninput="update()" class="sdpi-item-value" />
+				<input id="clockwise" list="profile-suggestions" oninput="update()" class="sdpi-item-value" placeholder="Profile name or __PREVIOUS__" />
 			</div>
 		</div>
 	</body>

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -25,10 +25,26 @@ pub async fn get_selected_profile(device: String) -> Result<crate::shared::Profi
 
 #[allow(clippy::flat_map_identity)]
 #[command]
-pub async fn set_selected_profile(device: String, id: String) -> Result<(), Error> {
+/// Sets the selected profile for a device. Returns the resolved profile ID (e.g., if `id` is `PREVIOUS_PROFILE_KEY`).
+pub async fn set_selected_profile(device: String, mut id: String) -> Result<String, Error> {
 	let mut locks = acquire_locks_mut().await;
 	if !DEVICES.contains_key(&device) {
 		return Err(Error::new(format!("device {device} not found")));
+	}
+
+	if id == crate::store::profiles::PREVIOUS_PROFILE_KEY {
+		if let Some(prev) = crate::store::profiles::pop_profile_history(&device) {
+			id = prev;
+		} else {
+			let current = locks.device_stores.get_selected_profile(&device)?;
+			return Ok(current);
+		}
+	} else {
+		if let Ok(current) = locks.device_stores.get_selected_profile(&device) {
+			if current != id {
+				crate::store::profiles::push_profile_history(&device, &current);
+			}
+		}
 	}
 
 	// If a profile save is pending for this device, save it immediately to prevent losing profile data
@@ -90,9 +106,10 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	}
 	store.save()?;
 
-	locks.device_stores.set_selected_profile(&device, id)?;
+	locks.device_stores.set_selected_profile(&device, id.clone())?;
 
-	Ok(())
+	// Return the resolved profile ID so the frontend updates UI/folders with actual profile name instead of __PREVIOUS__
+	Ok(id)
 }
 
 #[command]

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -140,6 +140,7 @@ pub struct Settings {
 	pub separatewine: bool,
 	pub developer: bool,
 	pub disableelgato: bool,
+	pub profile_history_size: usize,
 }
 
 impl Default for Settings {
@@ -159,6 +160,7 @@ impl Default for Settings {
 			separatewine: false,
 			developer: false,
 			disableelgato: false,
+			profile_history_size: 20,
 		}
 	}
 }

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -288,6 +288,34 @@ pub static PROFILE_STORES: LazyLock<RwLock<ProfileStores>> = LazyLock::new(|| Rw
 /// A singleton object to manage Store instances for device configurations.
 pub static DEVICE_STORES: LazyLock<RwLock<DeviceStores>> = LazyLock::new(|| RwLock::new(DeviceStores { stores: HashMap::new() }));
 
+pub const PREVIOUS_PROFILE_KEY: &str = "__PREVIOUS__";
+
+/// In-memory profile history stack per device for navigating back to previous profiles.
+pub static PROFILE_HISTORY: LazyLock<DashMap<String, Vec<String>>> = LazyLock::new(DashMap::new);
+
+pub fn push_profile_history(device: &str, profile: &str) {
+	let max_history = crate::store::get_settings().value.profile_history_size;
+	if max_history == 0 {
+		return;
+	}
+	let mut entry = PROFILE_HISTORY.entry(device.to_owned()).or_default();
+	if entry.last().map(|s| s.as_str()) != Some(profile) {
+		entry.push(profile.to_owned());
+		if entry.len() > max_history {
+			entry.remove(0);
+		}
+	}
+}
+
+pub fn pop_profile_history(device: &str) -> Option<String> {
+	if let Some(mut entry) = PROFILE_HISTORY.get_mut(device) {
+		entry.pop()
+	} else {
+		None
+	}
+}
+
+
 pub struct Locks<'a> {
 	#[allow(dead_code)]
 	pub device_stores: RwLockReadGuard<'a, DeviceStores>,

--- a/src/components/ProfileManager.svelte
+++ b/src/components/ProfileManager.svelte
@@ -37,17 +37,19 @@
 	export let profile: Profile;
 	export async function setProfile(id: string) {
 		if (!device || !id) return;
-		if (value != id) {
+		if (value != id && id != "__PREVIOUS__") {
 			value = id;
 			return;
 		}
-		await invoke("set_selected_profile", { device: device.id, id });
+		const actualId: string = await invoke("set_selected_profile", { device: device.id, id });
 		profile = await invoke("get_selected_profile", { device: device.id });
+		value = profile.id;
+		oldValue = value;
 
-		let folder = id.includes("/") ? id.split("/")[0] : "";
+		let folder = actualId.includes("/") ? actualId.split("/")[0] : "";
 		if (folders[folder]) {
-			if (!folders[folder].includes(id)) folders[folder].push(id);
-		} else folders[folder] = [id];
+			if (!folders[folder].includes(actualId)) folders[folder].push(actualId);
+		} else folders[folder] = [actualId];
 		folders = folders;
 
 		$inspectedInstance = null;

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -104,6 +104,19 @@
 		</div>
 
 		<div class="flex flex-row items-center m-2 space-x-2">
+			<label for="settings-profile_history_size" class="text-neutral-400">{$t("settings.profile_history_size")}</label>
+			<input
+				type="number"
+				min="0"
+				max="100"
+				bind:value={$settings.profile_history_size}
+				class="w-16 px-1 text-neutral-300 border border-neutral-600 rounded-lg"
+				id="settings-profile_history_size"
+			/>
+			<Tooltip>{$t("settings.profile_history_size.tooltip")}</Tooltip>
+		</div>
+
+		<div class="flex flex-row items-center m-2 space-x-2">
 			<label for="settings-sleep_when_computer_locked" class="text-neutral-400">{$t("settings.sleep_when_computer_locked")}</label>
 			<input type="checkbox" bind:checked={$settings.sleep_when_computer_locked} id="settings-sleep_when_computer_locked" />
 			<Tooltip>{$t("settings.sleep_when_computer_locked.tooltip")}</Tooltip>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -12,6 +12,7 @@ export type Settings = {
 	separatewine: boolean;
 	developer: boolean;
 	disableelgato: boolean;
+	profile_history_size: number;
 };
 
 import { invoke } from "@tauri-apps/api/core";

--- a/translations/en.json
+++ b/translations/en.json
@@ -136,6 +136,8 @@
 	"settings.language.tooltip": "{{PRODUCT_NAME}} itself is not yet completely translated. Changing this setting will translate the text from installed plugins into your language for those that support it.",
 	"settings.open_config": "Open config",
 	"settings.open_logs": "Open logs",
+	"settings.profile_history_size": "Profile history stack size:",
+	"settings.profile_history_size.tooltip": "Maximum number of previous profiles stored in memory per device for navigating back using __PREVIOUS__.",
 	"settings.restore_config.button": "Restore config",
 	"settings.restore_config.prompt": "You will be prompted to select a location to restore the backup from. This may take a while if you have many plugins or profiles. The application will restart after the restoration is complete.\n\nYou may encounter issues if you attempt to restore a backup from a different operating system or architecture.",
 	"settings.restore_config.title": "Restoring configuration",


### PR DESCRIPTION
### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---

https://github.com/nekename/OpenDeck/issues/394

Add support for going back to previous profiles using `__PREVIOUS__` .

Demo: https://youtu.be/aq_6olIkO28

Change works as follows:
- Profile history is ordered onto a stack.
- Profiles are added onto the stack when you change profiles.
- If you're on the default profile/starting page, pressing `__PREVIOUS__` does nothing as there is nothing on the stack.
- Switching to any profile adds the profile you're switching off of to the stack.
- Configurable stack limit in settings along with a tooltip explainer.