### PR TITLE
Save debounce

### DIFF
--- a/src-tauri/src/events/frontend/instances.rs
+++ b/src-tauri/src/events/frontend/instances.rs
@@ -1,7 +1,7 @@
 use super::Error;
 
 use crate::shared::{Action, ActionContext, ActionInstance, ActionState, Context, config_dir};
-use crate::store::profiles::{LocksMut, acquire_locks, acquire_locks_mut, get_instance_mut, get_slot, get_slot_mut, save_profile};
+use crate::store::profiles::{LocksMut, acquire_locks, acquire_locks_mut, get_instance_mut, get_slot, get_slot_mut, save_profile_now};
 
 use tauri::{AppHandle, Emitter, Manager, command};
 use tokio::fs::remove_dir_all;
@@ -44,7 +44,7 @@ pub async fn create_instance(app: AppHandle, mut action: Action, context: Contex
 			let _ = update_state(&app, parent.context.clone(), &mut locks).await;
 		}
 
-		save_profile(&context.device, &mut locks).await?;
+		save_profile_now(&context.device, &mut locks).await?;
 		drop(locks);
 		let _ = crate::events::outbound::will_appear::will_appear(&instance).await;
 
@@ -68,7 +68,7 @@ pub async fn create_instance(app: AppHandle, mut action: Action, context: Contex
 		*slot = Some(instance.clone());
 		let slot = slot.clone();
 
-		save_profile(&context.device, &mut locks).await?;
+		save_profile_now(&context.device, &mut locks).await?;
 		let _ = crate::events::outbound::will_appear::will_appear(&instance).await;
 
 		Ok(slot)
@@ -146,7 +146,7 @@ pub async fn move_instance(source: Context, destination: Context, retain: bool) 
 
 	let _ = crate::events::outbound::will_appear::will_appear(&new).await;
 
-	save_profile(&destination.device, &mut locks).await?;
+	save_profile_now(&destination.device, &mut locks).await?;
 
 	Ok(Some(new))
 }
@@ -190,7 +190,7 @@ pub async fn remove_instance(context: ActionContext) -> Result<(), Error> {
 		}
 	}
 
-	save_profile(&context.device, &mut locks).await?;
+	save_profile_now(&context.device, &mut locks).await?;
 
 	Ok(())
 }
@@ -219,7 +219,7 @@ pub async fn set_state(context: ActionContext, index: u16, state: ActionState) -
 	let reference = get_instance_mut(&context, &mut locks).await?.unwrap();
 	reference.states[index as usize] = state;
 	let clone = reference.clone();
-	save_profile(&context.device, &mut locks).await?;
+	save_profile_now(&context.device, &mut locks).await?;
 	crate::events::outbound::states::title_parameters_did_change(&clone, index).await?;
 	Ok(())
 }

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -37,6 +37,7 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	}
 
 	let selected_profile = locks.device_stores.get_selected_profile(&device)?;
+
 	if selected_profile != id {
 		let old_profile = &locks.profile_stores.get_profile_store(&DEVICES.get(&device).unwrap(), &selected_profile)?.value;
 		for instance in old_profile

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -1,7 +1,7 @@
 use super::Error;
 
 use crate::shared::DEVICES;
-use crate::store::profiles::{PROFILE_SAVE_DEBOUNCE, PROFILE_STORES, acquire_locks_mut, get_device_profiles, save_profile};
+use crate::store::profiles::{PROFILE_STORES, acquire_locks_mut, get_device_profiles, save_profile, save_profile_now};
 
 use tauri::{AppHandle, Emitter, Manager, command};
 
@@ -32,24 +32,11 @@ pub async fn set_selected_profile(device: String, id: String) -> Result<(), Erro
 	}
 
 	// If a profile save is pending for this device, save it immediately to prevent losing profile data
-	let entries = PROFILE_SAVE_DEBOUNCE
-		.iter()
-		.filter(|entry| entry.key().device == device)
-		.map(|entry| entry.key().clone())
-		.collect::<Vec<_>>();
-	if !entries.is_empty() {
-		for context in &entries {
-			if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(context) {
-				handle.abort();
-			}
-		}
-		if let Err(error) = save_profile(&device, &mut locks).await {
-			log::error!("Failed to save profile for device {device}: {error}");
-		}
+	if let Err(error) = save_profile_now(&device, &mut locks).await {
+		log::error!("Failed to save profile for device {device}: {error}");
 	}
 
 	let selected_profile = locks.device_stores.get_selected_profile(&device)?;
-
 	if selected_profile != id {
 		let old_profile = &locks.profile_stores.get_profile_store(&DEVICES.get(&device).unwrap(), &selected_profile)?.value;
 		for instance in old_profile

--- a/src-tauri/src/events/frontend/profiles.rs
+++ b/src-tauri/src/events/frontend/profiles.rs
@@ -1,7 +1,7 @@
 use super::Error;
 
 use crate::shared::DEVICES;
-use crate::store::profiles::{PROFILE_STORES, acquire_locks_mut, get_device_profiles, save_profile, save_profile_now};
+use crate::store::profiles::{PROFILE_STORES, acquire_locks_mut, get_device_profiles, save_profile_now};
 
 use tauri::{AppHandle, Emitter, Manager, command};
 

--- a/src-tauri/src/events/inbound/devices.rs
+++ b/src-tauri/src/events/inbound/devices.rs
@@ -71,7 +71,7 @@ pub async fn deregister_device(uuid: &str, event: PayloadEvent<String>) -> Resul
 			let _ = crate::events::outbound::will_appear::will_disappear(instance, false).await;
 		}
 
-		// Flush any pending profile writes before removing the device
+		// Flush any pending profile writes before removing the device.
 		if let Err(error) = crate::store::profiles::save_profile_now(&event.payload, &mut locks).await {
 			log::error!("Failed to flush profile for device {}: {error}", event.payload);
 		}

--- a/src-tauri/src/events/inbound/devices.rs
+++ b/src-tauri/src/events/inbound/devices.rs
@@ -71,6 +71,11 @@ pub async fn deregister_device(uuid: &str, event: PayloadEvent<String>) -> Resul
 			let _ = crate::events::outbound::will_appear::will_disappear(instance, false).await;
 		}
 
+		// Flush any pending profile writes before removing the device
+		if let Err(error) = crate::store::profiles::save_profile_now(&event.payload, &mut locks).await {
+			log::error!("Failed to flush profile for device {}: {error}", &event.payload);
+		}
+
 		if let Ok(profiles) = get_device_profiles(&event.payload) {
 			for profile in profiles {
 				locks.profile_stores.remove_profile(&event.payload, &profile);

--- a/src-tauri/src/events/inbound/devices.rs
+++ b/src-tauri/src/events/inbound/devices.rs
@@ -73,7 +73,7 @@ pub async fn deregister_device(uuid: &str, event: PayloadEvent<String>) -> Resul
 
 		// Flush any pending profile writes before removing the device
 		if let Err(error) = crate::store::profiles::save_profile_now(&event.payload, &mut locks).await {
-			log::error!("Failed to flush profile for device {}: {error}", &event.payload);
+			log::error!("Failed to flush profile for device {}: {error}", event.payload);
 		}
 
 		if let Ok(profiles) = get_device_profiles(&event.payload) {

--- a/src-tauri/src/events/inbound/settings.rs
+++ b/src-tauri/src/events/inbound/settings.rs
@@ -1,6 +1,6 @@
 use crate::events::outbound::settings as outbound;
 use crate::shared::ActionContext;
-use crate::store::profiles::{acquire_locks, acquire_locks_mut, get_instance, get_instance_mut, save_profile};
+use crate::store::profiles::{acquire_locks, acquire_locks_mut, get_instance, get_instance_mut, mark_profile_stale};
 
 use std::io::Write;
 use std::str::FromStr;
@@ -11,7 +11,7 @@ pub async fn set_settings(event: super::ContextAndPayloadEvent<serde_json::Value
 	if let Some(instance) = get_instance_mut(&event.context, &mut locks).await? {
 		instance.settings = event.payload;
 		outbound::did_receive_settings(instance, !from_property_inspector).await?;
-		save_profile(&event.context.device, &mut locks).await?;
+		mark_profile_stale(&event.context.device, &mut locks).await?;
 	}
 
 	Ok(())

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -1,7 +1,7 @@
 use super::ContextAndPayloadEvent;
 
 use crate::events::frontend::instances::update_state;
-use crate::store::profiles::{acquire_locks_mut, debounce_profile_save, get_instance_mut, save_profile};
+use crate::store::profiles::{acquire_locks_mut, get_instance_mut, save_profile};
 
 use anyhow::bail;
 use serde::Deserialize;
@@ -97,14 +97,7 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
 
-	if let Some(image) = &event.payload.image
-		&& image.trim().starts_with("data:")
-	{
-		debounce_profile_save(event.context);
-	} else {
-		save_profile(&event.context.device, &mut locks).await?;
-	}
-
+	save_profile(&event.context.device, &mut locks).await?;
 	Ok(())
 }
 

--- a/src-tauri/src/events/inbound/states.rs
+++ b/src-tauri/src/events/inbound/states.rs
@@ -1,7 +1,7 @@
 use super::ContextAndPayloadEvent;
 
 use crate::events::frontend::instances::update_state;
-use crate::store::profiles::{acquire_locks_mut, get_instance_mut, save_profile};
+use crate::store::profiles::{acquire_locks_mut, get_instance_mut, mark_profile_stale};
 
 use anyhow::bail;
 use serde::Deserialize;
@@ -59,7 +59,7 @@ pub async fn set_title(event: ContextAndPayloadEvent<SetTitlePayload>) -> Result
 		}
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	save_profile(&event.context.device, &mut locks).await?;
+	mark_profile_stale(&event.context.device, &mut locks).await?;
 
 	Ok(())
 }
@@ -97,7 +97,7 @@ pub async fn set_image(mut event: ContextAndPayloadEvent<SetImagePayload>) -> Re
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
 
-	save_profile(&event.context.device, &mut locks).await?;
+	mark_profile_stale(&event.context.device, &mut locks).await?;
 	Ok(())
 }
 
@@ -141,7 +141,7 @@ pub async fn set_state(event: ContextAndPayloadEvent<SetStatePayload>) -> Result
 		instance.current_state = event.payload.state;
 		update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await?;
 	}
-	save_profile(&event.context.device, &mut locks).await?;
+	mark_profile_stale(&event.context.device, &mut locks).await?;
 
 	Ok(())
 }

--- a/src-tauri/src/events/outbound/keypad.rs
+++ b/src-tauri/src/events/outbound/keypad.rs
@@ -2,7 +2,7 @@ use super::{GenericInstancePayload, send_to_plugin};
 
 use crate::events::frontend::instances::{key_moved, update_state};
 use crate::shared::{ActionContext, Context};
-use crate::store::profiles::{acquire_locks_mut, get_slot_mut, save_profile};
+use crate::store::profiles::{acquire_locks_mut, get_slot_mut, mark_profile_stale};
 
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -75,7 +75,7 @@ pub async fn key_down(device: &str, key: u8) -> Result<(), anyhow::Error> {
 			let _ = update_state(crate::APP_HANDLE.get().unwrap(), child, &mut locks).await;
 		}
 
-		save_profile(device, &mut locks).await?;
+		mark_profile_stale(device, &mut locks).await?;
 	} else if instance.action.uuid == "opendeck.toggleaction" {
 		let children = instance.children.as_ref().unwrap();
 		if children.is_empty() {
@@ -168,7 +168,7 @@ pub async fn key_up(device: &str, key: u8) -> Result<(), anyhow::Error> {
 	};
 
 	let _ = update_state(crate::APP_HANDLE.get().unwrap(), instance.context.clone(), &mut locks).await;
-	save_profile(device, &mut locks).await?;
+	mark_profile_stale(device, &mut locks).await?;
 
 	Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,6 +21,7 @@ use shared::PRODUCT_NAME;
 
 use std::sync::OnceLock;
 use std::time::Duration;
+
 use tauri::{
 	AppHandle, Builder, Manager, WindowEvent,
 	menu::{IconMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem},

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ use events::frontend;
 use shared::PRODUCT_NAME;
 
 use std::sync::OnceLock;
-
+use std::time::Duration;
 use tauri::{
 	AppHandle, Builder, Manager, WindowEvent,
 	menu::{IconMenuItemBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem},
@@ -29,6 +29,7 @@ use tauri::{
 use tauri_plugin_log::{Target, TargetKind};
 
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+const SAVE_PROBE: Duration = Duration::from_secs(20);
 
 fn show_window(app: &AppHandle) -> Result<(), tauri::Error> {
 	#[cfg(target_os = "macos")]
@@ -196,6 +197,16 @@ If you have already donated, thank you so much for your support!"#,
 					tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 				}
 			});
+
+			tokio::spawn(async {
+				loop {
+					tokio::time::sleep(SAVE_PROBE).await;
+					if let Err(error) = store::profiles::flush_stale_profiles().await {
+						log::error!("Failed to flush stale profiles: {error}");
+					}
+				}
+			});
+
 			plugins::initialise_plugins();
 			application_watcher::init_application_watcher();
 			device_sleep::init_device_sleep();
@@ -380,6 +391,13 @@ If you have already donated, thank you so much for your support!"#,
 		if let tauri::RunEvent::Exit = event {
 			#[cfg(windows)]
 			futures::executor::block_on(plugins::deactivate_plugins());
+
+			let flush_future = store::profiles::flush_stale_profiles();
+			match tauri::async_runtime::block_on(flush_future) {
+				Ok(_) => log::info!("Successfully flushed all stale profiles on exit"),
+				Err(error) => log::error!("Failed to flush stale profiles on exit: {error}"),
+			}
+
 			tokio::spawn(elgato::reset_devices());
 			use tauri_plugin_aptabase::EventTracker;
 			app.flush_events_blocking();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,7 +30,7 @@ use tauri::{
 use tauri_plugin_log::{Target, TargetKind};
 
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
-const SAVE_PROBE: Duration = Duration::from_secs(20);
+const SAVE_PROBE: Duration = Duration::from_secs(30);
 
 fn show_window(app: &AppHandle) -> Result<(), tauri::Error> {
 	#[cfg(target_os = "macos")]

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -441,7 +441,7 @@ pub struct Profile {
 	pub infobars: Vec<Option<ActionInstance>>,
 
 	#[serde(skip)]
-	pub profile_stale: bool,
+	pub stale: bool,
 }
 
 /// A map of category names to a list of actions in that category.

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -439,6 +439,9 @@ pub struct Profile {
 	pub sliders: Vec<Option<ActionInstance>>,
 	#[serde(default)]
 	pub infobars: Vec<Option<ActionInstance>>,
+
+	#[serde(skip)]
+	pub profile_stale: bool,
 }
 
 /// A map of category names to a list of actions in that category.

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -39,7 +39,7 @@ impl ProfileStores {
 				sliders: Vec::new(),
 				infobars: Vec::new(),
 
-				profile_stale: false,
+				stale: false,
 			};
 
 			let mut store = Store::new(&canonical_id, &config_dir().join("profiles"), default).context(format!("Failed to create store for profile {}", canonical_id))?;
@@ -373,7 +373,7 @@ pub async fn mark_profile_stale(device_id: &str, locks: &mut LocksMut<'_>) -> Re
 	let selected_profile = locks.device_stores.get_selected_profile(device_id)?;
 	let device = DEVICES.get(device_id).ok_or_else(|| anyhow!("device not found"))?;
 	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;
-	store.value.profile_stale = true;
+	store.value.stale = true;
 	Ok(())
 }
 
@@ -382,9 +382,9 @@ pub async fn save_profile_now(device_id: &str, locks: &mut LocksMut<'_>) -> Resu
 	let device = DEVICES.get(device_id).ok_or_else(|| anyhow!("device not found"))?;
 	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;
 
-	if store.value.profile_stale {
+	if store.value.stale {
 		store.save()?;
-		store.value.profile_stale = false;
+		store.value.stale = false;
 	}
 
 	Ok(())
@@ -393,9 +393,9 @@ pub async fn save_profile_now(device_id: &str, locks: &mut LocksMut<'_>) -> Resu
 pub async fn flush_stale_profiles() -> Result<(), anyhow::Error> {
 	let mut locks = acquire_locks_mut().await;
 	for store in locks.profile_stores.stores.values_mut() {
-		if store.value.profile_stale {
+		if store.value.stale {
 			store.save()?;
-			store.value.profile_stale = false;
+			store.value.stale = false;
 		}
 	}
 	Ok(())

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -8,10 +8,9 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use anyhow::{Context, anyhow};
-use dashmap::DashMap;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use tokio::task::JoinHandle;
 
 pub struct ProfileStores {
 	stores: HashMap<String, Store<Profile>>,
@@ -40,6 +39,8 @@ impl ProfileStores {
 				keys: Vec::new(),
 				sliders: Vec::new(),
 				infobars: Vec::new(),
+
+				profile_stale: false,
 			};
 
 			let mut store = Store::new(&canonical_id, &config_dir().join("profiles"), default).context(format!("Failed to create store for profile {}", canonical_id))?;
@@ -372,24 +373,33 @@ pub async fn get_instance_mut<'a>(context: &crate::shared::ActionContext, locks:
 pub async fn save_profile(device: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
 	let selected_profile = locks.device_stores.get_selected_profile(device)?;
 	let device = DEVICES.get(device).ok_or_else(|| anyhow!("device not found"))?;
-	let store = locks.profile_stores.get_profile_store(&device, &selected_profile)?;
-	store.save()
+	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;
+	store.value.profile_stale = true;
+	Ok(())
 }
 
-pub static PROFILE_SAVE_DEBOUNCE: LazyLock<DashMap<crate::shared::ActionContext, JoinHandle<()>>> = LazyLock::new(DashMap::new);
-pub fn debounce_profile_save(context: crate::shared::ActionContext) {
-	if let Some((_, handle)) = PROFILE_SAVE_DEBOUNCE.remove(&context) {
-		handle.abort();
+pub async fn save_profile_now(device: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
+	let selected_profile = locks.device_stores.get_selected_profile(device)?;
+	let device_info = DEVICES.get(device).ok_or_else(|| anyhow!("device not found"))?;
+	let store = locks.profile_stores.get_profile_store_mut(&device_info, &selected_profile).await?;
+
+	if store.value.profile_stale {
+		debug!("Saving profile: {}", store.value.id);
+		store.save()?;
+		store.value.profile_stale = false;
 	}
-	PROFILE_SAVE_DEBOUNCE.insert(
-		context.clone(),
-		tokio::spawn(async move {
-			tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-			let mut locks = acquire_locks_mut().await;
-			if let Err(error) = save_profile(&context.device, &mut locks).await {
-				log::error!("Failed to save profile for device {}: {error}", context.device);
-			}
-			PROFILE_SAVE_DEBOUNCE.remove(&context);
-		}),
-	);
+
+	Ok(())
+}
+
+pub async fn flush_stale_profiles() -> Result<(), anyhow::Error> {
+	let mut locks = acquire_locks_mut().await;
+	for store in locks.profile_stores.stores.values_mut() {
+		if store.value.profile_stale {
+			debug!("Flushing Stale Profile: {}", store.value.id);
+			store.save()?;
+			store.value.profile_stale = false;
+		}
+	}
+	Ok(())
 }

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -369,7 +369,7 @@ pub async fn get_instance_mut<'a>(context: &crate::shared::ActionContext, locks:
 	Ok(None)
 }
 
-pub async fn save_profile(device_id: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
+pub async fn mark_profile_stale(device_id: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
 	let selected_profile = locks.device_stores.get_selected_profile(device_id)?;
 	let device = DEVICES.get(device_id).ok_or_else(|| anyhow!("device not found"))?;
 	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use anyhow::{Context, anyhow};
-use log::debug;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -370,21 +369,20 @@ pub async fn get_instance_mut<'a>(context: &crate::shared::ActionContext, locks:
 	Ok(None)
 }
 
-pub async fn save_profile(device: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
-	let selected_profile = locks.device_stores.get_selected_profile(device)?;
-	let device = DEVICES.get(device).ok_or_else(|| anyhow!("device not found"))?;
+pub async fn save_profile(device_id: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
+	let selected_profile = locks.device_stores.get_selected_profile(device_id)?;
+	let device = DEVICES.get(device_id).ok_or_else(|| anyhow!("device not found"))?;
 	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;
 	store.value.profile_stale = true;
 	Ok(())
 }
 
-pub async fn save_profile_now(device: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
-	let selected_profile = locks.device_stores.get_selected_profile(device)?;
-	let device_info = DEVICES.get(device).ok_or_else(|| anyhow!("device not found"))?;
-	let store = locks.profile_stores.get_profile_store_mut(&device_info, &selected_profile).await?;
+pub async fn save_profile_now(device_id: &str, locks: &mut LocksMut<'_>) -> Result<(), anyhow::Error> {
+	let selected_profile = locks.device_stores.get_selected_profile(device_id)?;
+	let device = DEVICES.get(device_id).ok_or_else(|| anyhow!("device not found"))?;
+	let store = locks.profile_stores.get_profile_store_mut(&device, &selected_profile).await?;
 
 	if store.value.profile_stale {
-		debug!("Saving profile: {}", store.value.id);
 		store.save()?;
 		store.value.profile_stale = false;
 	}
@@ -396,7 +394,6 @@ pub async fn flush_stale_profiles() -> Result<(), anyhow::Error> {
 	let mut locks = acquire_locks_mut().await;
 	for store in locks.profile_stores.stores.values_mut() {
 		if store.value.profile_stale {
-			debug!("Flushing Stale Profile: {}", store.value.id);
 			store.save()?;
 			store.value.profile_stale = false;
 		}

--- a/src-tauri/src/store/simplified_profile.rs
+++ b/src-tauri/src/store/simplified_profile.rs
@@ -216,6 +216,8 @@ impl DiskProfile {
 			keys: self.keys.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 			sliders: self.sliders.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 			infobars: self.infobars.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
+
+			profile_stale: false,
 		}
 	}
 }

--- a/src-tauri/src/store/simplified_profile.rs
+++ b/src-tauri/src/store/simplified_profile.rs
@@ -217,7 +217,7 @@ impl DiskProfile {
 			sliders: self.sliders.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 			infobars: self.infobars.into_iter().map(|x| x.map(|v| v.into_action_instance(path))).collect(),
 
-			profile_stale: false,
+			stale: false,
 		}
 	}
 }


### PR DESCRIPTION
This is a relatively simple change that replaces the existing debounce behaviour with a global write timer. Profiles will be saved (if changed) every 20 seconds, or will be force saved in the following situations:

1. The user is changing the profile
2. The device has been unplugged
3. OpenDeck is exiting

This is primarily to solve issues with redundant frequent writes when some plugins spam updates on buttons. The save duration can be adjusted at the top of `main.rs`.


### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.