### PR TITLE
Fix/plugin profile switch clean

### DIFF
--- a/src-tauri/src/events/inbound/misc.rs
+++ b/src-tauri/src/events/inbound/misc.rs
@@ -43,14 +43,38 @@ pub async fn show_ok(event: ContextEvent) -> Result<(), anyhow::Error> {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+pub struct SwitchProfilePayload {
+	profile: Option<String>,
+	page: Option<u32>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SwitchProfileEvent {
 	device: String,
-	profile: String,
+	payload: SwitchProfilePayload,
 }
 
 pub async fn switch_profile(event: SwitchProfileEvent) -> Result<(), anyhow::Error> {
+	let Some(profile) = event.payload.profile.clone() else {
+		anyhow::bail!("switchToProfile without a profile is not supported yet");
+	};
+
+	eprintln!("[profile-switch] reçu device={} profile={} page={:?}", event.device, profile, event.payload.page);
+
+	crate::events::frontend::profiles::set_selected_profile(event.device.clone(), profile.clone()).await?;
+
+	eprintln!("[profile-switch] succès device={} profile={}", event.device, profile);
+
 	let app_handle = crate::APP_HANDLE.get().unwrap();
-	app_handle.get_webview_window("main").unwrap().emit("switch_profile", event)?;
+
+	app_handle.get_webview_window("main").unwrap().emit(
+		"switch_profile",
+		serde_json::json!({
+				"device": event.device,
+				"profile": profile
+		}),
+	)?;
+
 	Ok(())
 }
 

--- a/src-tauri/src/events/inbound/misc.rs
+++ b/src-tauri/src/events/inbound/misc.rs
@@ -59,11 +59,9 @@ pub async fn switch_profile(event: SwitchProfileEvent) -> Result<(), anyhow::Err
 		anyhow::bail!("switchToProfile without a profile is not supported yet");
 	};
 
-	eprintln!("[profile-switch] reçu device={} profile={} page={:?}", event.device, profile, event.payload.page);
+	log::debug!("Switching profile for device {} to {} on page {:?}", event.device, profile, event.payload.page);
 
 	crate::events::frontend::profiles::set_selected_profile(event.device.clone(), profile.clone()).await?;
-
-	eprintln!("[profile-switch] succès device={} profile={}", event.device, profile);
 
 	let app_handle = crate::APP_HANDLE.get().unwrap();
 

--- a/src-tauri/src/events/inbound/mod.rs
+++ b/src-tauri/src/events/inbound/mod.rs
@@ -66,6 +66,7 @@ pub enum InboundEventType {
 	ShowOk(ContextEvent),
 	SendToPropertyInspector(ContextAndPayloadEvent<serde_json::Value>),
 	SendToPlugin(ContextAndPayloadEvent<serde_json::Value>),
+	#[serde(alias = "switchToProfile")]
 	SwitchProfile(misc::SwitchProfileEvent),
 	DeviceBrightness(misc::DeviceBrightnessEvent),
 }
@@ -111,10 +112,7 @@ pub async fn process_incoming_message(data: Result<Message, Error>, uuid: &str, 
 				if event.context != uuid {
 					return;
 				}
-			} else if matches!(decoded, InboundEventType::SwitchProfile(_) | InboundEventType::DeviceBrightness(_))
-				&& uuid != "com.amansprojects.starterpack.sdPlugin"
-				&& uuid != "opendeck_alternative_elgato_implementation"
-			{
+			} else if matches!(decoded, InboundEventType::DeviceBrightness(_)) && uuid != "com.amansprojects.starterpack.sdPlugin" && uuid != "opendeck_alternative_elgato_implementation" {
 				return;
 			}
 		}


### PR DESCRIPTION
## Summary

This PR restores compatibility with the official Stream Deck SDK `switchToProfile` command.

Although OpenDeck already had internal support for profile switching, plugins using the official `@elgato/streamdeck` SDK could not successfully switch profiles.

## Changes

- Accept the official `switchToProfile` event name using a serde alias.
- Parse the official SDK payload format (`payload.profile` and `payload.page`).
- Allow regular plugins to call `switchToProfile`.
- Update the selected profile immediately in the backend.
- Notify the frontend after the profile has been changed.

## Why

The official Stream Deck SDK exposes the following API:

```ts
streamDeck.profiles.switchToProfile(deviceId, profile, page);
```

Before this change, the command could not be used correctly because:

- OpenDeck only accepted a different event name.
- The payload format was incompatible with the official SDK.
- The command was restricted to internal plugins.
- Receiving the event did not actually update the active profile.

As a result, plugins built against the official SDK were unable to switch profiles.

This PR makes the official SDK command work as expected while preserving the existing frontend behavior.

## Testing

Tested with a custom plugin using the official `@elgato/streamdeck` SDK.

Verified that:

- `switchToProfile()` is received correctly.
- the requested profile becomes the active profile.
- the frontend updates accordingly.
- profile switching works repeatedly in both directions.
- existing functionality continues to work normally.

## Notes

This PR is independent from my touchscreen swipe event PR.

It only improves compatibility with the official Stream Deck SDK.



### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [] I will keep "Allow edits from maintainers" enabled for this pull request.

---
