### PR TITLE
fix: stop discarding key image quality on the way to the device

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -61,7 +61,18 @@ pub async fn update_image(context: &crate::shared::Context, image: Option<&str>)
 				let (r, g, b) = extract_average_colour(&image::load_from_memory(&bytes)?);
 				device.set_touchpoint_color(context.position - key_count, r, g, b).await?;
 			} else {
-				device.set_button_image(context.position, image::load_from_memory(&bytes)?).await?;
+				// Scale to the key size ourselves. elgato-streamdeck would otherwise do it
+				// with FilterType::Nearest, which discards the antialiasing of whatever the
+				// plugin drew: at the Stream Deck +'s 6:5 ratio (144 -> 120) that drops every
+				// sixth row and column and point-samples soft edges into stair-steps.
+				let img = image::load_from_memory(&bytes)?;
+				let (kw, kh) = kind.key_image_format().size;
+				let img = if img.dimensions() == (kw as u32, kh as u32) {
+					img
+				} else {
+					img.resize_exact(kw as u32, kh as u32, image::imageops::FilterType::Lanczos3)
+				};
+				device.set_button_image(context.position, img).await?;
 			}
 		} else if context.controller == "Encoder" {
 			let mut img = image::DynamicImage::new_rgb8(200, 100);

--- a/src-tauri/src/encoder_layouts.rs
+++ b/src-tauri/src/encoder_layouts.rs
@@ -39,7 +39,7 @@ pub async fn generate_encoder_image(context: &crate::shared::Context, fallback: 
 			let mut fallback_canvas = RgbaImage::from_pixel(200, 100, Rgba([0, 0, 0, 255]));
 			let fallback_img = image::load_from_memory(fallback)
 				.context("Failed to decode fallback image")?
-				.resize(72, 72, image::imageops::FilterType::Nearest);
+				.resize(72, 72, image::imageops::FilterType::Lanczos3);
 
 			overlay(&mut fallback_canvas, &fallback_img.to_rgba8(), 64, 14);
 

--- a/src/lib/rendererHelper.ts
+++ b/src/lib/rendererHelper.ts
@@ -176,7 +176,8 @@ export async function renderImage(
 
 	context.restore();
 
-	if (active && slotContext) setTimeout(async () => await invoke("update_image", { context: slotContext, image: canvas.toDataURL("image/jpeg") }), 10);
+	// PNG, not JPEG: this is an in-process invoke and the image is re-encoded as JPEG for the device anyway, so the lossy pass here only costs quality.
+	if (active && slotContext) setTimeout(async () => await invoke("update_image", { context: slotContext, image: canvas.toDataURL() }), 10);
 }
 
 export async function resizeImage(source: string): Promise<string | undefined> {


### PR DESCRIPTION
Fixes #411.

Key images reach the panel with their antialiasing destroyed — stair-stepped diagonals, strokes whose width visibly alternates along their length, and small text reduced to mush. Found while writing an ALSA plugin that draws its key faces as SVG, on 2.14.0 with a Stream Deck +.

The cause is in `elgato-streamdeck`: `convert_image_with_format` resamples every key image to the device's key size with `FilterType::Nearest`. At 144 → 120, a 6:5 ratio, that drops every sixth row and column and point-samples soft edges instead of averaging them. I've opened OpenActionAPI/rust-elgato-streamdeck#62 for it.

This PR fixes it from OpenDeck's side so it doesn't have to wait on a crate release, and makes two related changes.

**`elgato.rs` — scale to the key size before handing the image over.** With the image already at the target size, the crate's `resize_exact` is a no-op in effect, so the filter that runs is ours. This stays correct once #62 lands: that PR skips the resample entirely when the image already matches, so the two compose rather than fight.

**`rendererHelper.ts` — send the canvas as PNG, not JPEG.** That hop is an in-process Tauri invoke on a 144×144 image which is re-encoded as JPEG for the device anyway, so the lossy pass bought nothing but artefacts.

**`encoder_layouts.rs` — same filter change** on the fallback image path. Low impact, since the normal dial-strip path goes through `streamdeck-strip-render` at native 200×100 and is unaffected, but it was the same `FilterType::Nearest`.

### Testing

Rendering the same source image through the full pipeline twice, changing only the filter and keeping both JPEG passes, the `Nearest` output matches what my hardware shows and the filtered output is clean, with no change to the artwork.

I could not build the tree here: `hidapi` needs `libudev` headers that aren't installed on this machine. I type-checked each changed expression against `image` 0.25.10 with the same imports the surrounding files use, and `rustfmt --check` is clean on both Rust files; the TypeScript line stays inside your 160-column Prettier width. So this wants a real build and an on-device look before it goes in — I'd expect the visible difference to be obvious on any device with a non-square-ratio key size.
