### PR TITLE
fix(webserver): resolve plugin asset paths against the config directory

### DIFF
--- a/src-tauri/src/plugins/webserver.rs
+++ b/src-tauri/src/plugins/webserver.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use tiny_http::{Header, Response, Server};
 
@@ -38,9 +38,17 @@ pub async fn init_webserver(prefix: PathBuf) {
 		}
 		#[cfg(target_os = "windows")]
 		let url = url[1..].replace('/', "\\");
-		let path = Path::new(url.trim_end_matches("|opendeck_property_inspector").trim_end_matches("|opendeck_property_inspector_child"));
+		// Resolve the requested path relative to the config directory. The request URL is
+		// absolute-looking (e.g. "/plugins/..."), so without joining it to `prefix` it would
+		// be treated as a path from the filesystem root and every plugin asset (icons,
+		// property inspectors) would 404.
+		let path = prefix.join(
+			url.trim_end_matches("|opendeck_property_inspector")
+				.trim_end_matches("|opendeck_property_inspector_child")
+				.trim_start_matches(['/', '\\']),
+		);
 
-		if !matches!(tokio::fs::try_exists(path).await, Ok(true)) {
+		if !matches!(tokio::fs::try_exists(&path).await, Ok(true)) {
 			let _ = request.respond(Response::empty(404));
 			continue;
 		}
@@ -68,9 +76,7 @@ pub async fn init_webserver(prefix: PathBuf) {
 		// and requests the Svelte frontend to maximise the property inspector.
 
 		if url.ends_with("|opendeck_property_inspector") {
-			let path = &url[..url.len() - 28];
-
-			let mut content = tokio::fs::read_to_string(path).await.unwrap_or_default();
+			let mut content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
 			content += r#"
 				<div id="opendeck_iframe_container" style="position: absolute; z-index: 100; top: 0; left: 0; width: 100%; height: 100%; display: none;"></div>
 				<script>
@@ -144,9 +150,7 @@ pub async fn init_webserver(prefix: PathBuf) {
 			});
 			let _ = request.respond(response);
 		} else if url.ends_with("|opendeck_property_inspector_child") {
-			let path = &url[..url.len() - 34];
-
-			let mut content = tokio::fs::read_to_string(path).await.unwrap_or_default();
+			let mut content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
 			content = format!("<script>window.opener ??= window.parent;</script>{content}");
 
 			let mut response = Response::from_string(content);
@@ -157,7 +161,7 @@ pub async fn init_webserver(prefix: PathBuf) {
 			});
 			let _ = request.respond(response);
 		} else {
-			let mime_type = mime(&match Path::new(&url).extension() {
+			let mime_type = mime(&match path.extension() {
 				Some(extension) => extension.to_string_lossy().into_owned(),
 				None => "html".to_owned(),
 			});
@@ -168,12 +172,12 @@ pub async fn init_webserver(prefix: PathBuf) {
 			};
 
 			if mime_type.starts_with("text/") || mime_type == "image/svg+xml" {
-				let mut response = Response::from_string(tokio::fs::read_to_string(url).await.unwrap_or_default());
+				let mut response = Response::from_string(tokio::fs::read_to_string(&path).await.unwrap_or_default());
 				response.add_header(access_control_allow_origin);
 				response.add_header(content_type);
 				let _ = request.respond(response);
 			} else {
-				let mut response = Response::from_file(match tokio::fs::File::open(url).await {
+				let mut response = Response::from_file(match tokio::fs::File::open(&path).await {
 					Ok(file) => file.into_std().await,
 					Err(_) => continue,
 				});


### PR DESCRIPTION
## Problem

Every plugin asset served by the plugin webserver (port `PORT_BASE + 2`) returns **404**, so action icons always fall back to `/alert.png` (the yellow exclamation mark) and plugin property inspectors cannot load.

## Root cause

`init_webserver(prefix)` receives the config directory as `prefix`, but only uses it for the path-traversal security check — never to resolve the requested path:

```rust
let path = Path::new(url.trim_end_matches("|opendeck_property_inspector")...);
//            ^ url is the request URL, e.g. "/plugins/<uuid>/icons/runCommand.png" — ABSOLUTE
if !matches!(tokio::fs::try_exists(path).await, Ok(true)) {
    let _ = request.respond(Response::empty(404));   // <- every asset hits this
    continue;
}
```

Request URLs are absolute-looking (`"/plugins/..."`), so `Path::new(url)` is treated as a path from the **filesystem root** (e.g. `/plugins/<uuid>/icons/runCommand.png`), which doesn't exist. `try_exists` fails → 404.

Confirmed live against a running 2.14.0 instance:
```
curl http://localhost:<PORT_BASE+2>/plugins/<uuid>/icons/runCommand.png -> 404
curl http://localhost:<PORT_BASE+2>/plugins/<uuid>/propertyInspector/runCommand.html -> 404
```
while both files exist under the config directory. The frontend then renders `/alert.png` (`src/lib/rendererHelper.ts`: `if (!image) return ... "/alert.png"`).

## Fix

Join the request path to `prefix` and use that resolved path everywhere:

```rust
let path = prefix.join(
    url.trim_end_matches("|opendeck_property_inspector")
        .trim_end_matches("|opendeck_property_inspector_child")
        .trim_start_matches(['/', '\\']),
);
```

The property-inspector branches and the static-file branch now read from this resolved `path` instead of re-slicing the raw URL. The security check (`canonicalize().starts_with(prefix)`) now also runs against the resolved path, which is what it was intended to guard (previously it guarded an absolute path that never existed).

## Verification

`cargo check`, `cargo fmt --check`, and `cargo clippy` all pass in `src-tauri` with no new warnings.

## Notes

- Cross-platform: the existing Windows `url[1..].replace('/', "\\")` normalization is preserved; `trim_start_matches(['/', '\\'])` handles either separator before the `prefix.join`.
- This is independent of device hotplug; it affects all installs on every launch.