### PR TITLE
fix: correctly wake Stream Deck + after system resume

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -1,3 +1,4 @@
+use crate::device_sleep::is_device_sleeping;
 use crate::encoder_layouts::generate_encoder_image;
 use crate::events::inbound;
 
@@ -126,6 +127,15 @@ pub async fn reset_devices() {
 	for (_id, device) in ELGATO_DEVICES.read().await.iter() {
 		let _ = device.reset().await;
 		let _ = device.flush().await;
+	}
+}
+
+/// Wake up certain kinds of devices that do not wake themselves after the computer resumes from sleep.
+pub async fn wake_deeply_sleeping_devices() {
+	for (id, device) in ELGATO_DEVICES.read().await.iter() {
+		if device.kind() == Kind::Plus && !is_device_sleeping(id) {
+			set_brightness(id, crate::store::get_settings().value.brightness).await;
+		}
 	}
 }
 

--- a/src-tauri/src/power_events.rs
+++ b/src-tauri/src/power_events.rs
@@ -27,6 +27,9 @@ pub fn init_power_events() {
 				}
 				PowerState::Resume => {
 					tauri::async_runtime::spawn(async {
+						crate::elgato::wake_deeply_sleeping_devices().await;
+					});
+					tauri::async_runtime::spawn(async {
 						if let Err(error) = crate::events::outbound::misc::system_did_wake_up().await {
 							log::error!("Failed to send the systemDidWakeUp event: {error}");
 						}


### PR DESCRIPTION
This change should fix the behavior of the Stream Deck + where on computer suspend the screen would sleep (i.e. go dark), but on computer resume it would not wake back up. By automatically setting the brightness of the device when the system resumes, the Stream Deck + will properly wake. There is a check to prevent the Stream Deck + from waking up if the "Sleep when computer is locked" setting is enabled by checking if it was added to the sleeping devices collection.

### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.

---
