### PR TITLE
Enable using symlinks to share profiles across devices

### DIFF
--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -92,12 +92,13 @@ where
 
 	/// Save the relevant Store as a file
 	pub fn save(&self) -> Result<(), anyhow::Error> {
-		fs::create_dir_all(self.path.parent().unwrap())?;
+		let target_path = fs::canonicalize(&self.path).unwrap_or_else(|_| self.path.clone());
+		fs::create_dir_all(target_path.parent().unwrap())?;
 
 		let contents = serde_json::to_string_pretty(&T::into_value(&self.value)?)?;
 
-		let temp_path = self.path.with_extension("json.temp");
-		let backup_path = self.path.with_extension("json.bak");
+		let temp_path = target_path.with_extension("json.temp");
+		let backup_path = target_path.with_extension("json.bak");
 
 		// Write to temporary file
 		let mut temp_file = fs::OpenOptions::new().write(true).truncate(true).create(true).open(&temp_path)?;
@@ -108,12 +109,12 @@ where
 		drop(temp_file);
 
 		// If main file exists, back it up
-		if self.path.exists() {
-			fs::rename(&self.path, &backup_path)?;
+		if target_path.exists() {
+			fs::rename(&target_path, &backup_path)?;
 		}
 
 		// Rename temp file to main file
-		fs::rename(&temp_path, &self.path)?;
+		fs::rename(&temp_path, &target_path)?;
 
 		// Remove backup file if everything succeeded
 		if backup_path.exists() {

--- a/src-tauri/src/store/profiles.rs
+++ b/src-tauri/src/store/profiles.rs
@@ -243,7 +243,7 @@ pub fn get_device_profiles(device: &str) -> Result<Vec<String>, anyhow::Error> {
 	let entries = fs::read_dir(device_path)?;
 
 	for entry in entries.flatten() {
-		if entry.metadata()?.is_file() {
+		if entry.path().is_file() {
 			let mut id = entry.file_name().to_string_lossy().into_owned();
 			if id.ends_with(".json") {
 				id.truncate(id.len() - 5);
@@ -255,10 +255,10 @@ pub fn get_device_profiles(device: &str) -> Result<Vec<String>, anyhow::Error> {
 				continue;
 			}
 			profiles.push(id);
-		} else if entry.metadata()?.is_dir() {
+		} else if entry.path().is_dir() {
 			let entries = fs::read_dir(entry.path())?;
 			for subentry in entries.flatten() {
-				if subentry.metadata()?.is_file() {
+				if subentry.path().is_file() {
 					let mut id = format!("{}/{}", entry.file_name().to_string_lossy(), &subentry.file_name().to_string_lossy());
 					if id.ends_with(".json") {
 						id.truncate(id.len() - 5);


### PR DESCRIPTION
With these changes, OpenDeck shows and dereferences symlinked profiles properly, and keeps profiles that are symlinks as such on saving by dereferencing.

Tested against 0.24.0 through a rebuilt debian package.


### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [X] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [X] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [X] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [X] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [X] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [X] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [X] I will keep "Allow edits from maintainers" enabled for this pull request.

---
