### PR TITLE
feat: support configurable encoder position

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -164,6 +164,7 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 				rows: kind.row_count(),
 				columns: kind.column_count(),
 				encoders: kind.encoder_count(),
+				encoder_position: crate::shared::EncoderPosition::Bottom,
 				touchpoints: kind.touchpoint_count(),
 				infobars: if kind == Kind::Neo { 1 } else { 0 },
 				r#type: device_type,

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -28,6 +28,14 @@ pub fn copy_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), std:
 }
 
 /// Metadata of a device.
+#[derive(Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EncoderPosition {
+	Top,
+	#[default]
+	Bottom,
+}
+
 #[serde_inline_default]
 #[derive(Clone, Deserialize, Serialize)]
 pub struct DeviceInfo {
@@ -38,6 +46,8 @@ pub struct DeviceInfo {
 	pub rows: u8,
 	pub columns: u8,
 	pub encoders: u8,
+	#[serde(default)]
+	pub encoder_position: EncoderPosition,
 	#[serde_inline_default(0)]
 	pub touchpoints: u8,
 	#[serde_inline_default(0)]
@@ -46,6 +56,38 @@ pub struct DeviceInfo {
 }
 
 pub static DEVICES: LazyLock<DashMap<String, DeviceInfo>> = LazyLock::new(DashMap::new);
+
+#[cfg(test)]
+mod tests {
+	use super::{DeviceInfo, EncoderPosition};
+
+	fn device_json(encoder_position: Option<&str>) -> String {
+		let encoder_position = encoder_position.map_or_else(String::new, |position| format!(r#", "encoder_position": "{position}""#));
+		format!(
+			r#"{{
+				"id": "test-device",
+				"name": "Test device",
+				"rows": 2,
+				"columns": 3,
+				"encoders": 1,
+				"type": 0
+				{encoder_position}
+			}}"#,
+		)
+	}
+
+	#[test]
+	fn encoder_position_defaults_to_bottom() {
+		let device: DeviceInfo = serde_json::from_str(&device_json(None)).unwrap();
+		assert!(matches!(device.encoder_position, EncoderPosition::Bottom));
+	}
+
+	#[test]
+	fn encoder_position_accepts_top() {
+		let device: DeviceInfo = serde_json::from_str(&device_json(Some("top"))).unwrap();
+		assert!(matches!(device.encoder_position, EncoderPosition::Top));
+	}
+}
 
 /// Get the application configuration directory.
 pub fn config_dir() -> std::path::PathBuf {

--- a/src/components/DeviceView.svelte
+++ b/src/components/DeviceView.svelte
@@ -77,17 +77,20 @@
 
 	$: overflowsX = Math.max(device.columns, device.encoders, device.touchpoints) > 8;
 	$: overflowsY = device.rows + Math.min(device.encoders, 1) + Math.min(device.touchpoints, 1) > 4;
+	$: encodersFirst = device.encoder_position === "top";
 
 	// Grid navigation: track focused cell and compute row lengths for arrow key movement.
 	let focusedRow = 0;
 	let focusedCol = 0;
 
 	$: gridRowLengths = [
+		...(encodersFirst && device.encoders > 0 ? [device.encoders] : []),
 		...Array(device.rows).fill(device.columns),
-		...(device.encoders > 0 ? [device.encoders] : []),
+		...(!encodersFirst && device.encoders > 0 ? [device.encoders] : []),
 		...(device.touchpoints > 0 || device.infobars > 0 ? [device.touchpoints + device.infobars] : []),
 	];
-	$: encoderRowIndex = device.rows;
+	$: keypadRowOffset = encodersFirst && device.encoders > 0 ? 1 : 0;
+	$: encoderRowIndex = encodersFirst ? 0 : device.rows;
 	$: touchpointRowIndex = device.rows + (device.encoders > 0 ? 1 : 0);
 	$: keypadRowWidth = device.columns * 132;
 
@@ -177,6 +180,24 @@
 		on:keydown|capture={handleGridKeydown}
 		on:focusin={handleGridFocusin}
 	>
+		{#if encodersFirst}
+			<div class="flex flex-row justify-between" role="row" style={`width: ${keypadRowWidth}px;`}>
+				{#each { length: device.encoders } as _, i}
+					<Key
+						context={{ device: device.id, profile: profile.id, controller: "Encoder", position: i }}
+						bind:inslot={profile.sliders[i]}
+						on:dragover={handleDragOver}
+						on:drop={(event) => handleDrop(event, "Encoder", i)}
+						on:dragstart={(event) => handleDragStart(event, "Encoder", i)}
+						{handlePaste}
+						size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
+						label="{$t('device_view.encoder')} {i + 1}"
+						tabindex={focusedRow === encoderRowIndex && focusedCol === i ? 0 : -1}
+					/>
+				{/each}
+			</div>
+		{/if}
+
 		<div class="flex flex-col" role="rowgroup">
 			{#each { length: device.rows } as _, r}
 				<div class="flex flex-row" role="row">
@@ -190,28 +211,30 @@
 							{handlePaste}
 							size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
 							label="{$t('device_view.key')} {String.fromCharCode(65 + r)}{c + 1}"
-							tabindex={focusedRow === r && focusedCol === c ? 0 : -1}
+							tabindex={focusedRow === r + keypadRowOffset && focusedCol === c ? 0 : -1}
 						/>
 					{/each}
 				</div>
 			{/each}
 		</div>
 
-		<div class="flex flex-row justify-between" role="row" style={`width: ${keypadRowWidth}px;`}>
-			{#each { length: device.encoders } as _, i}
-				<Key
-					context={{ device: device.id, profile: profile.id, controller: "Encoder", position: i }}
-					bind:inslot={profile.sliders[i]}
-					on:dragover={handleDragOver}
-					on:drop={(event) => handleDrop(event, "Encoder", i)}
-					on:dragstart={(event) => handleDragStart(event, "Encoder", i)}
-					{handlePaste}
-					size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
-					label="{$t('device_view.encoder')} {i + 1}"
-					tabindex={focusedRow === encoderRowIndex && focusedCol === i ? 0 : -1}
-				/>
-			{/each}
-		</div>
+		{#if !encodersFirst}
+			<div class="flex flex-row justify-between" role="row" style={`width: ${keypadRowWidth}px;`}>
+				{#each { length: device.encoders } as _, i}
+					<Key
+						context={{ device: device.id, profile: profile.id, controller: "Encoder", position: i }}
+						bind:inslot={profile.sliders[i]}
+						on:dragover={handleDragOver}
+						on:drop={(event) => handleDrop(event, "Encoder", i)}
+						on:dragstart={(event) => handleDragStart(event, "Encoder", i)}
+						{handlePaste}
+						size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
+						label="{$t('device_view.encoder')} {i + 1}"
+						tabindex={focusedRow === encoderRowIndex && focusedCol === i ? 0 : -1}
+					/>
+				{/each}
+			</div>
+		{/if}
 
 		<div class="flex flex-row items-center" role="row">
 			{#each { length: device.touchpoints } as _, i}

--- a/src/lib/DeviceInfo.ts
+++ b/src/lib/DeviceInfo.ts
@@ -4,6 +4,7 @@ export type DeviceInfo = {
 	rows: number;
 	columns: number;
 	encoders: number;
+	encoder_position: "top" | "bottom";
 	touchpoints: number;
 	infobars: number;
 	type: number;


### PR DESCRIPTION
## What changed

- add an optional `encoder_position` device capability with `top` and `bottom` values
- preserve `bottom` as the default for existing built-in and plugin-provided devices
- render encoder controls before keypad rows when a device requests `top`
- keep keyboard grid navigation aligned with the visual row order
- mirror the new field in the TypeScript device type

## Why

Some controllers place rotary encoders above their LCD keys. OpenDeck currently always renders encoders below the keypad, so plugin-provided devices cannot represent their physical layout accurately without device-specific UI checks.

This keeps layout selection generic: device integrations opt into `top`, while all existing devices retain the current bottom placement by default.

## Validation

- `deno task check` — 0 errors and 0 warnings
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml encoder_position` — 2 passed
- physical layout tested with a Corsair Galleon 100 SD device plugin
