### PR TITLE
Let a device place its encoders among the keys

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -166,6 +166,8 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 				encoders: kind.encoder_count(),
 				touchpoints: kind.touchpoint_count(),
 				infobars: if kind == Kind::Neo { 1 } else { 0 },
+				// Every Elgato device keeps its dials in a row of their own.
+				encoder_slots: Vec::new(),
 				r#type: device_type,
 			},
 		},

--- a/src-tauri/src/shared.rs
+++ b/src-tauri/src/shared.rs
@@ -42,6 +42,11 @@ pub struct DeviceInfo {
 	pub touchpoints: u8,
 	#[serde_inline_default(0)]
 	pub infobars: u8,
+	/// Keypad positions that are physically a dial rather than a key, for devices where the
+	/// encoders sit among the keys instead of in a row of their own. Encoders listed here are
+	/// drawn in place; any not listed keep the row below the keypad.
+	#[serde_inline_default(Vec::new())]
+	pub encoder_slots: Vec<u16>,
 	pub r#type: u8,
 }
 

--- a/src/components/DeviceView.svelte
+++ b/src/components/DeviceView.svelte
@@ -75,8 +75,14 @@
 		}
 	}
 
+	// A device can place some of its encoders among the keys (`encoder_slots[i]` is the keypad
+	// position of encoder `i`), for hardware where a dial sits in the same strip as the keys
+	// rather than in a row of its own. Anything not placed keeps the row below the keypad.
+	$: inlineEncoderSlots = device.encoder_slots ?? [];
+	$: rowEncoders = Array.from({ length: device.encoders }, (_, i) => i).filter((i) => i >= inlineEncoderSlots.length);
+
 	$: overflowsX = Math.max(device.columns, device.encoders, device.touchpoints) > 8;
-	$: overflowsY = device.rows + Math.min(device.encoders, 1) + Math.min(device.touchpoints, 1) > 4;
+	$: overflowsY = device.rows + Math.min(rowEncoders.length, 1) + Math.min(device.touchpoints, 1) > 4;
 
 	// Grid navigation: track focused cell and compute row lengths for arrow key movement.
 	let focusedRow = 0;
@@ -84,11 +90,11 @@
 
 	$: gridRowLengths = [
 		...Array(device.rows).fill(device.columns),
-		...(device.encoders > 0 ? [device.encoders] : []),
+		...(rowEncoders.length > 0 ? [rowEncoders.length] : []),
 		...(device.touchpoints > 0 || device.infobars > 0 ? [device.touchpoints + device.infobars] : []),
 	];
 	$: encoderRowIndex = device.rows;
-	$: touchpointRowIndex = device.rows + (device.encoders > 0 ? 1 : 0);
+	$: touchpointRowIndex = device.rows + (rowEncoders.length > 0 ? 1 : 0);
 	$: keypadRowWidth = device.columns * 132;
 
 	function flatIndexFromRowCol(row: number, col: number): number {
@@ -181,24 +187,39 @@
 			{#each { length: device.rows } as _, r}
 				<div class="flex flex-row" role="row">
 					{#each { length: device.columns } as _, c}
-						<Key
-							context={{ device: device.id, profile: profile.id, controller: "Keypad", position: r * device.columns + c }}
-							bind:inslot={profile.keys[r * device.columns + c]}
-							on:dragover={handleDragOver}
-							on:drop={(event) => handleDrop(event, "Keypad", r * device.columns + c)}
-							on:dragstart={(event) => handleDragStart(event, "Keypad", r * device.columns + c)}
-							{handlePaste}
-							size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
-							label="{$t('device_view.key')} {String.fromCharCode(65 + r)}{c + 1}"
-							tabindex={focusedRow === r && focusedCol === c ? 0 : -1}
-						/>
+						{@const inlineEncoder = inlineEncoderSlots.indexOf(r * device.columns + c)}
+						{#if inlineEncoder >= 0}
+							<Key
+								context={{ device: device.id, profile: profile.id, controller: "Encoder", position: inlineEncoder }}
+								bind:inslot={profile.sliders[inlineEncoder]}
+								on:dragover={handleDragOver}
+								on:drop={(event) => handleDrop(event, "Encoder", inlineEncoder)}
+								on:dragstart={(event) => handleDragStart(event, "Encoder", inlineEncoder)}
+								{handlePaste}
+								size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
+								label="{$t('device_view.encoder')} {inlineEncoder + 1}"
+								tabindex={focusedRow === r && focusedCol === c ? 0 : -1}
+							/>
+						{:else}
+							<Key
+								context={{ device: device.id, profile: profile.id, controller: "Keypad", position: r * device.columns + c }}
+								bind:inslot={profile.keys[r * device.columns + c]}
+								on:dragover={handleDragOver}
+								on:drop={(event) => handleDrop(event, "Keypad", r * device.columns + c)}
+								on:dragstart={(event) => handleDragStart(event, "Keypad", r * device.columns + c)}
+								{handlePaste}
+								size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
+								label="{$t('device_view.key')} {String.fromCharCode(65 + r)}{c + 1}"
+								tabindex={focusedRow === r && focusedCol === c ? 0 : -1}
+							/>
+						{/if}
 					{/each}
 				</div>
 			{/each}
 		</div>
 
 		<div class="flex flex-row justify-between" role="row" style={`width: ${keypadRowWidth}px;`}>
-			{#each { length: device.encoders } as _, i}
+			{#each rowEncoders as i, c}
 				<Key
 					context={{ device: device.id, profile: profile.id, controller: "Encoder", position: i }}
 					bind:inslot={profile.sliders[i]}
@@ -208,7 +229,7 @@
 					{handlePaste}
 					size={device.id.startsWith("sd-") && device.rows == 4 && device.columns == 8 ? 192 : 144}
 					label="{$t('device_view.encoder')} {i + 1}"
-					tabindex={focusedRow === encoderRowIndex && focusedCol === i ? 0 : -1}
+					tabindex={focusedRow === encoderRowIndex && focusedCol === c ? 0 : -1}
 				/>
 			{/each}
 		</div>

--- a/src/lib/DeviceInfo.ts
+++ b/src/lib/DeviceInfo.ts
@@ -6,5 +6,6 @@ export type DeviceInfo = {
 	encoders: number;
 	touchpoints: number;
 	infobars: number;
+	encoder_slots: number[];
 	type: number;
 };


### PR DESCRIPTION
## The problem

`DeviceView` always draws encoders in a row below the keypad. That is right for every Elgato
device and for the Stream Deck+, but not for hardware that puts a dial *in* the same strip as
the keys.

The VSD Stream Dock N1 is portrait: a strip along the top edge holds two small screens with
buttons behind them and a third with the knob under it, and fifteen keys sit below. Whichever
way the strip is mapped into the grid, the knob ends up in a row of its own beneath fifteen
keys it is physically above, so the deck on screen is laid out differently from the one under
the user's hands. It is not cosmetic in use: you reach for the dial by looking at the app and
find the wrong end of the device.

## The change

A device may now report `encoder_slots`: the keypad position of each encoder that is
physically among the keys. `encoder_slots[i]` is where encoder `i` is drawn.

* Listed encoders are drawn in place of that keypad cell.
* Anything not listed keeps the row below the keypad, exactly as now.
* The field defaults to empty via `serde_inline_default`, so **every existing device and every
  plugin that does not send it is unaffected** -- including the Elgato path, which passes an
  empty vector explicitly.

Grid navigation follows the same split: the encoder row is only counted as a row when
something is left in it, and `overflowsY` likewise.

## Testing

Built and run against a VSD Stream Dock N1 through a mirajazz-based plugin
([tommasobbianchi/opendeck-vsd-n1](https://github.com/tommasobbianchi/opendeck-vsd-n1)) that
registers `encoder_slots: [2]`: the dial is drawn in the top strip next to the two buttons, and
the fifteen keys fill the rows below, matching the hardware. An Elgato Stream Deck was not
available to me, so the unchanged path is argued from the code rather than measured -- worth a
second pair of eyes on that.

Happy to adjust the shape of the field. An alternative would have been a single "encoders come
first" flag, but that still leaves the dial on a row of its own rather than in the strip where
it belongs, so it would not have solved this device.
