### PR TITLE
Keep a key's state update in the copy that survives a re-render

### DIFF
--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -51,7 +51,15 @@
 	}
 
 	listen("update_state", ({ payload }: { payload: { context: string; contents: ActionInstance | null } }) => {
-		if (payload.context == slot?.context) slot = payload.contents;
+		if (payload.context != slot?.context) return;
+		slot = payload.contents;
+		// The parent's `profile.keys[]` is the copy that survives a grid re-render, so a state
+		// update that only lands in the local `slot` is undone the next time anything sets
+		// `profile = profile` -- which is what made plugin-set images revert to the action's
+		// default icon (#152). Keep both copies in step, and move `lastInslot` with them so
+		// the write back does not immediately bounce through `update()`.
+		lastInslot = payload.contents;
+		inslot = payload.contents;
 	});
 
 	listen("key_moved", ({ payload }: { payload: { context: Context; pressed: boolean } }) => {

--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -197,46 +197,64 @@
 	}
 
 	$: accessibleLabel = label + (slot ? ": " + slot.action.name + (state?.show && state?.text ? " - " + state.text : "") : "");
+
+	// What this key does, written under it. A key that carries an icon carries no text -- the
+	// text would be drawn across the middle of the picture, on the hardware as well as here --
+	// so without this the editor is a grid of pictures and no words, and a picture is only
+	// obvious once you already know what it means.
+	//
+	// The state's name is where a profile says what its key is for: it is the manifest's
+	// per-state Name, it round-trips through the profile file, and nothing else reads it, so
+	// two keys of the same action can finally be told apart. Failing that, the action's own
+	// tooltip and name. None of the three reaches the device, so the glass stays clean.
+	$: caption = slot ? state?.name || slot.action.tooltip || slot.action.name || "" : "";
 </script>
 
-<div class="relative" style={`transform: scale(${(112 /* desired inner size */ / size) * scale});`}>
-	<canvas
-		bind:this={canvas}
-		class="relative border-3 border-neutral-700 rounded-3xl outline-none outline-offset-2 outline-blue-500"
-		style={`margin: ${-((size + 3 * 2 /* border */ - 132) /* desired outer size */ / 2)}px;`}
-		class:outline-solid={active && ((slot && $inspectedInstance == slot.context) || (context && $inspectedInstance == context))}
-		class:rounded-full!={context?.controller == "Encoder"}
-		class:rounded-lg!={context?.controller == "Infobar"}
-		class:bg-black={slot != null}
-		{width}
-		{height}
-		draggable={slot != null}
-		{tabindex}
-		{role}
-		aria-label={accessibleLabel}
-		on:dragstart
-		on:dragover
-		on:drop
-		on:click|stopPropagation={select}
-		on:dblclick|stopPropagation={triggerVirtualPress}
-		on:keydown={(e) => {
-			if (!active || !context) return;
-			if (e.key == "Enter") select(e);
-			else if (e.key == "F2") edit();
-			else if ((e.ctrlKey || e.metaKey) && e.key == "c") copy();
-			else if ((e.ctrlKey || e.metaKey) && e.key == "v") paste();
-			else if (e.key == "Delete") clear();
-			else if (e.key == "ContextMenu" || (e.shiftKey && e.key == "F10")) contextMenu(e);
-		}}
-		on:keyup|stopPropagation={(e) => {
-			if (!active || !context) return;
-			if (e.key == " ") select(e);
-		}}
-		on:focus={onfocus}
-		on:contextmenu={contextMenu}
-	/>
-	{#if isTouchPoint && !slot}
-		<div class="absolute left-1/4 top-1/2 w-1/2 border-t-4 border-neutral-700 pointer-events-none"></div>
+<div class="flex flex-col items-center">
+	<div class="relative" style={`transform: scale(${(112 /* desired inner size */ / size) * scale});`}>
+		<canvas
+			bind:this={canvas}
+			class="relative border-3 border-neutral-700 rounded-3xl outline-none outline-offset-2 outline-blue-500"
+			style={`margin: ${-((size + 3 * 2 /* border */ - 132) /* desired outer size */ / 2)}px;`}
+			class:outline-solid={active && ((slot && $inspectedInstance == slot.context) || (context && $inspectedInstance == context))}
+			class:rounded-full!={context?.controller == "Encoder"}
+			class:rounded-lg!={context?.controller == "Infobar"}
+			class:bg-black={slot != null}
+			{width}
+			{height}
+			draggable={slot != null}
+			{tabindex}
+			{role}
+			aria-label={accessibleLabel}
+			on:dragstart
+			on:dragover
+			on:drop
+			on:click|stopPropagation={select}
+			on:dblclick|stopPropagation={triggerVirtualPress}
+			on:keydown={(e) => {
+				if (!active || !context) return;
+				if (e.key == "Enter") select(e);
+				else if (e.key == "F2") edit();
+				else if ((e.ctrlKey || e.metaKey) && e.key == "c") copy();
+				else if ((e.ctrlKey || e.metaKey) && e.key == "v") paste();
+				else if (e.key == "Delete") clear();
+				else if (e.key == "ContextMenu" || (e.shiftKey && e.key == "F10")) contextMenu(e);
+			}}
+			on:keyup|stopPropagation={(e) => {
+				if (!active || !context) return;
+				if (e.key == " ") select(e);
+			}}
+			on:focus={onfocus}
+			on:contextmenu={contextMenu}
+		/>
+		{#if isTouchPoint && !slot}
+			<div class="absolute left-1/4 top-1/2 w-1/2 border-t-4 border-neutral-700 pointer-events-none"></div>
+		{/if}
+	</div>
+	{#if caption}
+		<span class="w-[104px] -mt-1 mb-0.5 text-[10px] leading-tight text-center text-neutral-400 line-clamp-2 break-words select-none pointer-events-none" title={caption}>
+			{caption}
+		</span>
 	{/if}
 </div>
 


### PR DESCRIPTION
Fixes the frontend half of #152, using the diagnosis @atomskz posted in that thread.

`Key.svelte` keeps two copies of a slot: the component-local `slot`, and the parent's
`profile.keys[]`, bound in as `inslot`. The `update_state` listener only wrote to the local one:

```ts
listen("update_state", ({ payload }) => {
    if (payload.context == slot?.context) slot = payload.contents;
});
```

So `profile.keys[]` kept the instance from `create_instance`, still carrying the action's
default image. The next time anything set `profile = profile` in `DeviceView` — after
`create_instance`, after `move_instance` — the reactive `update(inslot)` overwrote the fresh
`slot` with the stale one, and `Key` re-rendered and pushed the default image back to the
device.

This writes the update into both copies, and moves `lastInslot` with them so the write back
does not bounce straight through `update()` on the next tick.

## Testing

On a VSD Stream Dock N1, driving `setImage` for keys owned by the Starter Pack and Linux App
Launcher plugins (through `--process-message`, so the ownership check is not in the way).
Before: the image appeared and was replaced by the action's default icon on the next grid
re-render. After: it stays, survives a restart, and OpenDeck rasterises it to `0.png` as it
does for an image chosen in the editor.

I have not reproduced the original report's exact path (Stream Deck MK.2, disconnect and
reconnect, Multi OBS Controller) as I have none of that hardware, so this may not be the only
route to the symptom -- the reconnect path is worth a second look. It is one concrete cause,
and the one I could measure.
