### PR TITLE
fix: forward touch screen presses on the Stream Deck + XL

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -208,14 +208,14 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 				DeviceStateUpdate::EncoderUp(dial) => inbound::devices::encoder_up(press(dial)).await,
 				DeviceStateUpdate::TouchScreenPress(x, y) => {
 					let (position, x, y) = match kind {
-						Kind::Plus => ((x / 200) as u8, x % 200, y),
+						Kind::Plus | Kind::PlusXl => ((x / 200) as u8, x % 200, y),
 						_ => continue,
 					};
 					inbound::devices::touchscreen_press(touchscreen_press(position, x, y, false)).await
 				}
 				DeviceStateUpdate::TouchScreenLongPress(x, y) => {
 					let (position, x, y) = match kind {
-						Kind::Plus => ((x / 200) as u8, x % 200, y),
+						Kind::Plus | Kind::PlusXl => ((x / 200) as u8, x % 200, y),
 						_ => continue,
 					};
 					inbound::devices::touchscreen_press(touchscreen_press(position, x, y, true)).await


### PR DESCRIPTION
Fixes #436.

The TouchScreenPress and TouchScreenLongPress arms in elgato.rs only matched Kind::Plus, so taps on a + XL were dropped before reaching plugins. The + XL strip has six 200px segments, the same per-encoder width as the Plus, so the existing x / 200 mapping works unchanged.

Tested on a real Stream Deck + XL on Linux: taps arrive as touchTap with the right encoder index for every segment.

### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.