### PR TITLE
fix: scale key images to the key resolution with a proper filter

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -61,7 +61,13 @@ pub async fn update_image(context: &crate::shared::Context, image: Option<&str>)
 				let (r, g, b) = extract_average_colour(&image::load_from_memory(&bytes)?);
 				device.set_touchpoint_color(context.position - key_count, r, g, b).await?;
 			} else {
-				device.set_button_image(context.position, image::load_from_memory(&bytes)?).await?;
+				// Pre-scale to the key's native resolution: the device library
+				// otherwise resizes with nearest-neighbour, which visibly
+				// aliases key images (144 -> 120 on the Stream Deck +).
+				let img = image::load_from_memory(&bytes)?;
+				let (width, height) = kind.key_image_format().size;
+				let img = img.resize_exact(width as u32, height as u32, image::imageops::FilterType::Lanczos3);
+				device.set_button_image(context.position, img).await?;
 			}
 		} else if context.controller == "Encoder" {
 			let mut img = image::DynamicImage::new_rgb8(200, 100);


### PR DESCRIPTION
The device library resizes key images to the key resolution with nearest-neighbour (`FilterType::Nearest` in elgato-streamdeck's `images.rs`). Key images are composited on a 144 px canvas, so on 120 px keys (Stream Deck +) every image goes through a 6:5 nearest-neighbour squeeze: circles stair-step, strokes thinner than about 4 px drop out or jitter, and small text gets chewed. The LCD strip does not have this problem, which makes the quality gap between keys and touch screen quite visible on a Plus.

This pre-scales the image to the key's native resolution with Lanczos3 before handing it to the library, making the library's internal resize a no-op. It mirrors what the infobar path in the same function already does with `resize_exact(248, 58, FilterType::Lanczos3)`.

No behaviour change beyond image quality. Running on my Stream Deck + against real plugins since yesterday; the difference is immediately visible on any key with curved or fine artwork.

Draft mainly in case you would rather fix this inside elgato-streamdeck itself; happy to adjust.

### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.