### PR TITLE
Turn touch strip swipes into dial ticks on the Stream Deck + and + XL

### DIFF
--- a/src-tauri/src/elgato.rs
+++ b/src-tauri/src/elgato.rs
@@ -220,6 +220,17 @@ async fn init(device: AsyncStreamDeck, device_id: String) {
 					};
 					inbound::devices::touchscreen_press(touchscreen_press(position, x, y, true)).await
 				}
+				DeviceStateUpdate::TouchScreenSwipe((sx, _sy), (ex, _ey)) => {
+					let position = match kind {
+						Kind::Plus | Kind::PlusXl => (sx / 200) as u8,
+						_ => continue,
+					};
+					let ticks = ((ex as i32 - sx as i32) / 12).clamp(-127, 127) as i8;
+					if ticks == 0 {
+						continue;
+					}
+					inbound::devices::encoder_change(encoder(position, ticks)).await
+				}
 				_ => Ok(()),
 			} {
 				Ok(_) => (),


### PR DESCRIPTION
Swipes on the Plus touch strip are currently discarded (the `_ => Ok(())` arm of the device event loop). This turns them into dial rotation: a swipe becomes encoder ticks for the dial it started over, one tick per 12 px of horizontal travel. Dragging across a dial's panel moves its value by the drag distance, and any plugin that already handles `dialRotate` gets this for free; plugins see ordinary tick events, so there is no API or protocol change.

One limitation worth stating: the hardware reports a swipe once, at finger lift, with start and end coordinates, so the adjustment lands when the finger lifts rather than tracking the drag live. That is a firmware constraint, not a choice in this patch.

On the divisor: 12 px per tick makes a full 200 px panel drag about 16 ticks, which felt right against the physical dial's detents on my Stream Deck +, where I have been running this against real plugins. Happy to tune it, or gate the whole thing behind a setting, if you would prefer.

Vertical position is ignored on purpose; a swipe that crosses tile borders is attributed to the dial it started over.

### Preflight checklist

**If you remove this checklist, this pull request will be closed without explanation.**

- [x] I understand that if this pull request is about support for non-Elgato or non-Tacto hardware, it will be closed without explanation, as per issue #38.
- [x] I certify the compliance of this pull request with the [Jellyfin LLM/"AI" Development Policy](https://web.archive.org/web/20260414131310/https://jellyfin.org/docs/general/contributing/llm-policies/) adopted by the OpenDeck project.
- [x] I thoroughly understand the changes that I am proposing in this pull request, and I will be able to respond to questions and review feedback.
- [x] I reasonably believe that the changes that I am proposing are of production quality, or I am otherwise opening this pull request as a draft.
- [x] I have thoroughly reviewed the diff of my changes and ensured that I have neither introduced any unrelated additions, nor differences in unmodified code.
- [x] I have ensured that I have run the appropriate formatter on my changes and that my code produces no linter violations.
- [x] I will keep "Allow edits from maintainers" enabled for this pull request.
